### PR TITLE
Fix NPEs in controllers when calling endpoints with illegal enum values

### DIFF
--- a/xs2a-adapter-app/src/test/de/adorsys/xs2a/adapter/controller/ConsentControllerWebMvcTest.java
+++ b/xs2a-adapter-app/src/test/de/adorsys/xs2a/adapter/controller/ConsentControllerWebMvcTest.java
@@ -1,0 +1,34 @@
+package de.adorsys.xs2a.adapter.controller;
+
+import de.adorsys.xs2a.adapter.mapper.HeadersMapper;
+import de.adorsys.xs2a.adapter.service.ais.AccountInformationService;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@RunWith(SpringRunner.class)
+@WebMvcTest(ConsentController.class)
+public class ConsentControllerWebMvcTest {
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private AccountInformationService accountInformationService;
+    @MockBean
+    private HeadersMapper headersMapper;
+
+    @Test
+    public void illegalBookingStatus() throws Exception {
+        mockMvc.perform(get("/v1/accounts/resource-id/transactions").param("bookingStatus", "BOOKED"))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.tppMessages[0].text").value("Illegal value 'BOOKED' for parameter 'bookingStatus', allowed values: booked, pending, both"));
+    }
+}

--- a/xs2a-adapter-app/src/test/de/adorsys/xs2a/adapter/controller/PaymentControllerWebMvcTest.java
+++ b/xs2a-adapter-app/src/test/de/adorsys/xs2a/adapter/controller/PaymentControllerWebMvcTest.java
@@ -1,0 +1,48 @@
+package de.adorsys.xs2a.adapter.controller;
+
+import de.adorsys.xs2a.adapter.mapper.HeadersMapper;
+import de.adorsys.xs2a.adapter.mapper.PaymentInitiationScaStatusResponseMapper;
+import de.adorsys.xs2a.adapter.service.PaymentInitiationService;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.hamcrest.Matchers.startsWith;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@RunWith(SpringRunner.class)
+@WebMvcTest(PaymentController.class)
+public class PaymentControllerWebMvcTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private PaymentInitiationService paymentService;
+    @MockBean
+    private PaymentInitiationScaStatusResponseMapper paymentInitiationScaStatusResponseMapper;
+    @MockBean
+    private HeadersMapper headersMapper;
+
+    @Test
+    public void illegalPaymentService() throws Exception {
+        mockMvc.perform(get("/v1/PAYMENTS/sepa-credit-transfers/id"))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.tppMessages[0].text").value(
+                startsWith("Illegal value 'PAYMENTS' for parameter 'payment-service', allowed values: payments,")));
+    }
+
+    @Test
+    public void illegalPaymentProduct() throws Exception {
+        mockMvc.perform(get("/v1/payments/SEPA-CREDIT-TRANSFERS/id"))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.tppMessages[0].text").value(
+                startsWith("Illegal value 'SEPA-CREDIT-TRANSFERS' for parameter 'payment-product', allowed values: sepa-credit-transfers,")));
+    }
+}

--- a/xs2a-adapter-psd2-api/src/main/java/de/adorsys/xs2a/adapter/model/AccountAccessTO.java
+++ b/xs2a-adapter-psd2-api/src/main/java/de/adorsys/xs2a/adapter/model/AccountAccessTO.java
@@ -76,7 +76,7 @@ public class AccountAccessTO {
           return e;
         }
       }
-      return null;
+      throw new IllegalArgumentException(value);
     }
 
     @Override
@@ -102,7 +102,7 @@ public class AccountAccessTO {
           return e;
         }
       }
-      return null;
+      throw new IllegalArgumentException(value);
     }
 
     @Override

--- a/xs2a-adapter-psd2-api/src/main/java/de/adorsys/xs2a/adapter/model/AccountDetailsTO.java
+++ b/xs2a-adapter-psd2-api/src/main/java/de/adorsys/xs2a/adapter/model/AccountDetailsTO.java
@@ -179,7 +179,7 @@ public class AccountDetailsTO {
           return e;
         }
       }
-      return null;
+      throw new IllegalArgumentException(value);
     }
 
     @Override

--- a/xs2a-adapter-psd2-api/src/main/java/de/adorsys/xs2a/adapter/model/AccountStatusTO.java
+++ b/xs2a-adapter-psd2-api/src/main/java/de/adorsys/xs2a/adapter/model/AccountStatusTO.java
@@ -26,7 +26,7 @@ public enum AccountStatusTO {
         return e;
       }
     }
-    return null;
+    throw new IllegalArgumentException(value);
   }
 
   @Override

--- a/xs2a-adapter-psd2-api/src/main/java/de/adorsys/xs2a/adapter/model/AuthenticationTypeTO.java
+++ b/xs2a-adapter-psd2-api/src/main/java/de/adorsys/xs2a/adapter/model/AuthenticationTypeTO.java
@@ -28,7 +28,7 @@ public enum AuthenticationTypeTO {
         return e;
       }
     }
-    return null;
+    throw new IllegalArgumentException(value);
   }
 
   @Override

--- a/xs2a-adapter-psd2-api/src/main/java/de/adorsys/xs2a/adapter/model/BalanceTypeTO.java
+++ b/xs2a-adapter-psd2-api/src/main/java/de/adorsys/xs2a/adapter/model/BalanceTypeTO.java
@@ -36,7 +36,7 @@ public enum BalanceTypeTO {
         return e;
       }
     }
-    return null;
+    throw new IllegalArgumentException(value);
   }
 
   @Override

--- a/xs2a-adapter-psd2-api/src/main/java/de/adorsys/xs2a/adapter/model/BookingStatusTO.java
+++ b/xs2a-adapter-psd2-api/src/main/java/de/adorsys/xs2a/adapter/model/BookingStatusTO.java
@@ -26,7 +26,7 @@ public enum BookingStatusTO {
         return e;
       }
     }
-    return null;
+    throw new IllegalArgumentException(value);
   }
 
   @Override

--- a/xs2a-adapter-psd2-api/src/main/java/de/adorsys/xs2a/adapter/model/ChallengeDataTO.java
+++ b/xs2a-adapter-psd2-api/src/main/java/de/adorsys/xs2a/adapter/model/ChallengeDataTO.java
@@ -86,7 +86,7 @@ public class ChallengeDataTO {
           return e;
         }
       }
-      return null;
+      throw new IllegalArgumentException(value);
     }
 
     @Override

--- a/xs2a-adapter-psd2-api/src/main/java/de/adorsys/xs2a/adapter/model/ConsentStatusTO.java
+++ b/xs2a-adapter-psd2-api/src/main/java/de/adorsys/xs2a/adapter/model/ConsentStatusTO.java
@@ -32,7 +32,7 @@ public enum ConsentStatusTO {
         return e;
       }
     }
-    return null;
+    throw new IllegalArgumentException(value);
   }
 
   @Override

--- a/xs2a-adapter-psd2-api/src/main/java/de/adorsys/xs2a/adapter/model/DayOfExecutionTO.java
+++ b/xs2a-adapter-psd2-api/src/main/java/de/adorsys/xs2a/adapter/model/DayOfExecutionTO.java
@@ -82,7 +82,7 @@ public enum DayOfExecutionTO {
         return e;
       }
     }
-    return null;
+    throw new IllegalArgumentException(value);
   }
 
   @Override

--- a/xs2a-adapter-psd2-api/src/main/java/de/adorsys/xs2a/adapter/model/ExecutionRuleTO.java
+++ b/xs2a-adapter-psd2-api/src/main/java/de/adorsys/xs2a/adapter/model/ExecutionRuleTO.java
@@ -24,7 +24,7 @@ public enum ExecutionRuleTO {
         return e;
       }
     }
-    return null;
+    throw new IllegalArgumentException(value);
   }
 
   @Override

--- a/xs2a-adapter-psd2-api/src/main/java/de/adorsys/xs2a/adapter/model/FrequencyCodeTO.java
+++ b/xs2a-adapter-psd2-api/src/main/java/de/adorsys/xs2a/adapter/model/FrequencyCodeTO.java
@@ -36,7 +36,7 @@ public enum FrequencyCodeTO {
         return e;
       }
     }
-    return null;
+    throw new IllegalArgumentException(value);
   }
 
   @Override

--- a/xs2a-adapter-psd2-api/src/main/java/de/adorsys/xs2a/adapter/model/MessageCode2XXTO.java
+++ b/xs2a-adapter-psd2-api/src/main/java/de/adorsys/xs2a/adapter/model/MessageCode2XXTO.java
@@ -22,7 +22,7 @@ public enum MessageCode2XXTO {
         return e;
       }
     }
-    return null;
+    throw new IllegalArgumentException(value);
   }
 
   @Override

--- a/xs2a-adapter-psd2-api/src/main/java/de/adorsys/xs2a/adapter/model/MessageCodeTO.java
+++ b/xs2a-adapter-psd2-api/src/main/java/de/adorsys/xs2a/adapter/model/MessageCodeTO.java
@@ -90,7 +90,7 @@ public enum MessageCodeTO {
         return e;
       }
     }
-    return null;
+    throw new IllegalArgumentException(value);
   }
 
   @Override

--- a/xs2a-adapter-psd2-api/src/main/java/de/adorsys/xs2a/adapter/model/PaymentProductTO.java
+++ b/xs2a-adapter-psd2-api/src/main/java/de/adorsys/xs2a/adapter/model/PaymentProductTO.java
@@ -36,7 +36,7 @@ public enum PaymentProductTO {
         return e;
       }
     }
-    return null;
+    throw new IllegalArgumentException(value);
   }
 
   @Override

--- a/xs2a-adapter-psd2-api/src/main/java/de/adorsys/xs2a/adapter/model/PaymentServiceTO.java
+++ b/xs2a-adapter-psd2-api/src/main/java/de/adorsys/xs2a/adapter/model/PaymentServiceTO.java
@@ -26,7 +26,7 @@ public enum PaymentServiceTO {
         return e;
       }
     }
-    return null;
+    throw new IllegalArgumentException(value);
   }
 
   @Override

--- a/xs2a-adapter-psd2-api/src/main/java/de/adorsys/xs2a/adapter/model/PurposeCodeTO.java
+++ b/xs2a-adapter-psd2-api/src/main/java/de/adorsys/xs2a/adapter/model/PurposeCodeTO.java
@@ -592,7 +592,7 @@ public enum PurposeCodeTO {
         return e;
       }
     }
-    return null;
+    throw new IllegalArgumentException(value);
   }
 
   @Override

--- a/xs2a-adapter-psd2-api/src/main/java/de/adorsys/xs2a/adapter/model/ScaStatusTO.java
+++ b/xs2a-adapter-psd2-api/src/main/java/de/adorsys/xs2a/adapter/model/ScaStatusTO.java
@@ -36,7 +36,7 @@ public enum ScaStatusTO {
         return e;
       }
     }
-    return null;
+    throw new IllegalArgumentException(value);
   }
 
   @Override

--- a/xs2a-adapter-psd2-api/src/main/java/de/adorsys/xs2a/adapter/model/TppMessageCategoryTO.java
+++ b/xs2a-adapter-psd2-api/src/main/java/de/adorsys/xs2a/adapter/model/TppMessageCategoryTO.java
@@ -24,7 +24,7 @@ public enum TppMessageCategoryTO {
         return e;
       }
     }
-    return null;
+    throw new IllegalArgumentException(value);
   }
 
   @Override

--- a/xs2a-adapter-psd2-api/src/main/java/de/adorsys/xs2a/adapter/model/TransactionStatusTO.java
+++ b/xs2a-adapter-psd2-api/src/main/java/de/adorsys/xs2a/adapter/model/TransactionStatusTO.java
@@ -48,7 +48,7 @@ public enum TransactionStatusTO {
         return e;
       }
     }
-    return null;
+    throw new IllegalArgumentException(value);
   }
 
   @Override

--- a/xs2a-adapter-rest-impl/src/test/java/de/adorsys/xs2a/adapter/controller/ConsentControllerTest.java
+++ b/xs2a-adapter-rest-impl/src/test/java/de/adorsys/xs2a/adapter/controller/ConsentControllerTest.java
@@ -17,8 +17,6 @@ import org.junit.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
@@ -35,10 +33,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import static org.springframework.http.MediaType.APPLICATION_JSON_UTF8_VALUE;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@SpringBootTest
-@AutoConfigureMockMvc
 public class ConsentControllerTest {
     private static final int HTTP_CODE_200 = 200;
 
@@ -104,5 +102,12 @@ public class ConsentControllerTest {
                                 .content("{}"))
                 .andExpect(status().is(HttpStatus.BAD_REQUEST.value()))
                 .andReturn();
+    }
+
+    @Test
+    public void getTransactionWithoutBookingStatusParamRespondsWithBadRequestAndClearErrorMessage()  throws Exception{
+        mockMvc.perform(get("/v1/accounts/resource-id/transactions"))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.tppMessages[0].text").value("Required parameter 'bookingStatus' is missing"));
     }
 }

--- a/xs2a-adapter-rest-server/src/main/java/de/adorsys/xs2a/adapter/config/PropertyEditorControllerAdvice.java
+++ b/xs2a-adapter-rest-server/src/main/java/de/adorsys/xs2a/adapter/config/PropertyEditorControllerAdvice.java
@@ -1,0 +1,28 @@
+package de.adorsys.xs2a.adapter.config;
+
+import de.adorsys.xs2a.adapter.model.BookingStatusTO;
+import de.adorsys.xs2a.adapter.model.PaymentProductTO;
+import de.adorsys.xs2a.adapter.model.PaymentServiceTO;
+import org.springframework.core.convert.ConversionService;
+import org.springframework.core.convert.TypeDescriptor;
+import org.springframework.core.convert.support.ConvertingPropertyEditorAdapter;
+import org.springframework.web.bind.WebDataBinder;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.InitBinder;
+
+@ControllerAdvice
+public class PropertyEditorControllerAdvice {
+
+    private final ConversionService conversionService;
+
+    public PropertyEditorControllerAdvice(ConversionService conversionService) {
+        this.conversionService = conversionService;
+    }
+
+    @InitBinder
+    void initBinder(WebDataBinder dataBinder) {
+        dataBinder.registerCustomEditor(BookingStatusTO.class, new ConvertingPropertyEditorAdapter(conversionService, TypeDescriptor.valueOf(BookingStatusTO.class)));
+        dataBinder.registerCustomEditor(PaymentServiceTO.class, new ConvertingPropertyEditorAdapter(conversionService, TypeDescriptor.valueOf(PaymentServiceTO.class)));
+        dataBinder.registerCustomEditor(PaymentProductTO.class, new ConvertingPropertyEditorAdapter(conversionService, TypeDescriptor.valueOf(PaymentProductTO.class)));
+    }
+}


### PR DESCRIPTION
PropertyEditors look like the only possible way to prevent the fallback
to default conversion logic that tries to match a string against enum
fields.