### PR TITLE
Age bank error handling

### DIFF
--- a/xs2a-adapter-rest-impl/src/main/java/de/adorsys/xs2a/adapter/config/RestExceptionHandler.java
+++ b/xs2a-adapter-rest-impl/src/main/java/de/adorsys/xs2a/adapter/config/RestExceptionHandler.java
@@ -105,6 +105,15 @@ public class RestExceptionHandler extends ResponseEntityExceptionHandler {
         return handleAsBadRequest(exception.getMessage());
     }
 
+    @ExceptionHandler
+    ResponseEntity handleErrorResponseException(ErrorResponseException exception) {
+        HttpStatus httpStatus = HttpStatus.valueOf(exception.getStatusCode());
+        HttpHeaders httpHeaders = headersMapper.toHttpHeaders(exception.getResponseHeaders());
+        ErrorResponse errorResponse = exception.getErrorResponse().orElse(null);
+
+        return new ResponseEntity<>(errorResponse, httpHeaders, httpStatus);
+    }
+
     private ResponseEntity<Object> handleAsBadRequest(String errorText) {
         HttpStatus httpStatus = HttpStatus.BAD_REQUEST;
         ErrorResponse errorResponse = buildErrorResponse(TppMessageCategoryTO.ERROR.name(), httpStatus.name(), errorText);


### PR DESCRIPTION
change should pass error message from bank to client.

Example error message:
"{"tppMessages":[{"category":"ERROR","code":"PSU_CREDENTIALS_INVALID","text":"authorisation PSU for consent was failed"}]}"

is actually producing message for client:
{"uuid":null,"messageList":[{"key":"class feign.FeignException","severity":"ERROR","field":null,"renderedMessage":"status 401 reading AccountInformationClient#updateConsentsPsuData(String,String,Map,ObjectNode)","paramsMap":null}]}