### PR TITLE
`xs2a-adapter-service-api`. BasePaymentInitiationService - fix initiateSinglePayment URL, change path constants visibility so they can be reused in extensions

### DIFF
--- a/docs/release_notes/DRAFT_Release_notes_0.0.4.adoc
+++ b/docs/release_notes/DRAFT_Release_notes_0.0.4.adoc
@@ -23,3 +23,4 @@
 - `xs2a-adapter-service-remote`. PaymentInitiationServiceImpl fixed problem with payment initiation status
 - `xs2a-adapter-service-api`. AccountDetails - add missing @JsonValue annotations for AvailableAccountsEnum and AllPsd2Enum
 - `xs2a-adapter-rest-impl`. index, main - fixed mdl-tooltip bug
+- `xs2a-adapter-service-api`. BasePaymentInitiationService - fix initiateSinglePayment URL, change path constants visibility so they can be reused in extensions

--- a/xs2a-adapter-service-api-adapter/src/main/java/de/adorsys/xs2a/adapter/adapter/BaseAccountInformationService.java
+++ b/xs2a-adapter-service-api-adapter/src/main/java/de/adorsys/xs2a/adapter/adapter/BaseAccountInformationService.java
@@ -35,13 +35,13 @@ import static java.util.function.Function.identity;
 
 public class BaseAccountInformationService extends AbstractService implements AccountInformationService {
 
-    private static final String V1 = "v1";
-    private static final String CONSENTS = "consents";
-    private static final String ACCOUNTS = "accounts";
-    private static final String TRANSACTIONS = "transactions";
-    private static final String BALANCES = "balances";
+    protected static final String V1 = "v1";
+    protected static final String CONSENTS = "consents";
+    protected static final String ACCOUNTS = "accounts";
+    protected static final String TRANSACTIONS = "transactions";
+    protected static final String BALANCES = "balances";
 
-    private final String baseUri;
+    protected final String baseUri;
     private final Request.Builder.Interceptor requestBuilderInterceptor;
 
     public BaseAccountInformationService(String baseUri, HttpClient httpClient) {

--- a/xs2a-adapter-service-api-adapter/src/main/java/de/adorsys/xs2a/adapter/adapter/BasePaymentInitiationService.java
+++ b/xs2a-adapter-service-api-adapter/src/main/java/de/adorsys/xs2a/adapter/adapter/BasePaymentInitiationService.java
@@ -35,9 +35,9 @@ import static java.util.function.Function.identity;
 
 public class BasePaymentInitiationService extends AbstractService implements PaymentInitiationService {
 
-    private static final String V1 = "v1";
-    private static final String PAYMENTS = "payments";
-    private final String baseUri;
+    protected static final String V1 = "v1";
+    protected static final String PAYMENTS = "payments";
+    protected final String baseUri;
     private final Request.Builder.Interceptor requestBuilderInterceptor;
 
     public BasePaymentInitiationService(String baseUri, HttpClient httpClient) {
@@ -77,7 +77,7 @@ public class BasePaymentInitiationService extends AbstractService implements Pay
                 throw new IllegalArgumentException("Unsupported payment product media type");
         }
 
-        Response<T> response = httpClient.post(StringUri.fromElements(baseUri, V1, PAYMENTS, paymentProduct.getSlug()))
+        Response<T> response = httpClient.post(StringUri.fromElements(getSinglePaymentBaseUri(), paymentProduct.getSlug()))
             .jsonBody(bodyString)
             .headers(headersMap)
             .send(requestBuilderInterceptor, jsonResponseHandler(klass));

--- a/xs2a-adapter-service-remote/src/main/java/de/adorsys/xs2a/adapter/service/impl/AccountInformationServiceImpl.java
+++ b/xs2a-adapter-service-remote/src/main/java/de/adorsys/xs2a/adapter/service/impl/AccountInformationServiceImpl.java
@@ -57,15 +57,20 @@ public class AccountInformationServiceImpl implements AccountInformationService 
     private final TransactionsReportMapper transactionsReportMapper = Mappers.getMapper(TransactionsReportMapper.class);
     private final StartScaProcessResponseMapper scaProcessResponseMapper = Mappers.getMapper(StartScaProcessResponseMapper.class);
     private final ResponseHeadersMapper responseHeadersMapper = Mappers.getMapper(ResponseHeadersMapper.class);
-    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final ObjectMapper objectMapper;
 
     public AccountInformationServiceImpl(AccountInformationClient client) {
         this.client = client;
+        this.objectMapper = new ObjectMapper();
         objectMapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
         objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
         objectMapper.registerModule(new JavaTimeModule());
         objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+    }
 
+    public AccountInformationServiceImpl(AccountInformationClient client, ObjectMapper objectMapper) {
+        this.client = client;
+        this.objectMapper = objectMapper;
     }
 
     @Override

--- a/xs2a-adapter-service-remote/src/main/java/de/adorsys/xs2a/adapter/service/impl/PaymentInitiationServiceImpl.java
+++ b/xs2a-adapter-service-remote/src/main/java/de/adorsys/xs2a/adapter/service/impl/PaymentInitiationServiceImpl.java
@@ -19,13 +19,36 @@ package de.adorsys.xs2a.adapter.service.impl;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import de.adorsys.xs2a.adapter.api.remote.PaymentInitiationClient;
-import de.adorsys.xs2a.adapter.mapper.*;
-import de.adorsys.xs2a.adapter.model.*;
+import de.adorsys.xs2a.adapter.mapper.PaymentInitiationAuthorisationResponseMapper;
+import de.adorsys.xs2a.adapter.mapper.PaymentInitiationRequestResponseMapper;
+import de.adorsys.xs2a.adapter.mapper.PaymentInitiationScaStatusResponseMapper;
+import de.adorsys.xs2a.adapter.mapper.PaymentInitiationStatusMapper;
+import de.adorsys.xs2a.adapter.mapper.SinglePaymentInformationMapper;
+import de.adorsys.xs2a.adapter.mapper.StartScaProcessResponseMapper;
+import de.adorsys.xs2a.adapter.model.AuthorisationsTO;
+import de.adorsys.xs2a.adapter.model.PaymentInitationRequestResponse201TO;
+import de.adorsys.xs2a.adapter.model.PaymentInitiationStatusResponse200JsonTO;
+import de.adorsys.xs2a.adapter.model.PaymentInitiationWithStatusResponseTO;
+import de.adorsys.xs2a.adapter.model.PaymentProductTO;
+import de.adorsys.xs2a.adapter.model.PaymentServiceTO;
+import de.adorsys.xs2a.adapter.model.ScaStatusResponseTO;
+import de.adorsys.xs2a.adapter.model.StartScaprocessResponseTO;
 import de.adorsys.xs2a.adapter.service.PaymentInitiationService;
 import de.adorsys.xs2a.adapter.service.RequestHeaders;
 import de.adorsys.xs2a.adapter.service.Response;
 import de.adorsys.xs2a.adapter.service.mapper.ResponseHeadersMapper;
-import de.adorsys.xs2a.adapter.service.model.*;
+import de.adorsys.xs2a.adapter.service.model.PaymentInitiationAuthorisationResponse;
+import de.adorsys.xs2a.adapter.service.model.PaymentInitiationRequestResponse;
+import de.adorsys.xs2a.adapter.service.model.PaymentInitiationScaStatusResponse;
+import de.adorsys.xs2a.adapter.service.model.PaymentInitiationStatus;
+import de.adorsys.xs2a.adapter.service.model.ScaStatusResponse;
+import de.adorsys.xs2a.adapter.service.model.SelectPsuAuthenticationMethod;
+import de.adorsys.xs2a.adapter.service.model.SelectPsuAuthenticationMethodResponse;
+import de.adorsys.xs2a.adapter.service.model.SinglePaymentInitiationInformationWithStatusResponse;
+import de.adorsys.xs2a.adapter.service.model.StartScaProcessResponse;
+import de.adorsys.xs2a.adapter.service.model.TransactionAuthorisation;
+import de.adorsys.xs2a.adapter.service.model.UpdatePsuAuthentication;
+import de.adorsys.xs2a.adapter.service.model.UpdatePsuAuthenticationResponse;
 import org.mapstruct.factory.Mappers;
 import org.springframework.http.ResponseEntity;
 
@@ -40,10 +63,15 @@ public class PaymentInitiationServiceImpl implements PaymentInitiationService {
     private final PaymentInitiationAuthorisationResponseMapper authorisationResponseMapper = Mappers.getMapper(PaymentInitiationAuthorisationResponseMapper.class);
     private final StartScaProcessResponseMapper scaProcessResponseMapper = Mappers.getMapper(StartScaProcessResponseMapper.class);
     private final ResponseHeadersMapper responseHeadersMapper = Mappers.getMapper(ResponseHeadersMapper.class);
-    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final ObjectMapper objectMapper;
 
     public PaymentInitiationServiceImpl(PaymentInitiationClient paymentInitiationClient) {
+        this(paymentInitiationClient, new ObjectMapper());
+    }
+
+    public PaymentInitiationServiceImpl(PaymentInitiationClient paymentInitiationClient, ObjectMapper objectMapper) {
         this.client = paymentInitiationClient;
+        this.objectMapper = objectMapper;
     }
 
     @Override


### PR DESCRIPTION
+ Additional commit for allowing custom ObjectMapper for PaymentInitiationServiceImpl and AccountInformationServiceImpl in `xs2a-adapter-service-remote`