### PR TITLE
Fix integ helm values, deploymentConfig template

### DIFF
--- a/devops/charts/env/integ/env.yaml
+++ b/devops/charts/env/integ/env.yaml
@@ -5,6 +5,6 @@ adapter:
   route: xs2a-adapter-integ.cloud.adorsys.de
   namespace: xs2a-adapter-integ
   tag: develop
-  aspspConfig: false
+  aspspConfig: true
 logback:
-  enabled: true
+  enabled: false

--- a/devops/charts/templates/xs2a-adapter/deployment.yaml
+++ b/devops/charts/templates/xs2a-adapter/deployment.yaml
@@ -87,7 +87,7 @@ spec:
         - name: xs2a-adapter-config
           persistentVolumeClaim:
             claimName: xs2a-adapter-config
-        {{- if .Values.adapter.aspspConfig }}
+        {{- if .Values.logback.enabled }}
         - configMap:
             defaultMode: 292
             name: xs2a-adapter-logging-config


### PR DESCRIPTION
Causes an error during installation

Error: render error in "xs2a-adapter/templates/xs2a-adapter/deployment.yaml": template: xs2a-adapter/templates/xs2a-adapter/deployment.yaml:17:26: executing "xs2a-adapter/templates/xs2a-adapter/deployment.yaml" at <include (print $.Tem...>: error calling include: template: xs2a-adapter/templates/xs2a-adapter/configmap.yaml:10:28: executing "xs2a-adapter/templates/xs2a-adapter/configmap.yaml" at <.Values.logback.file>: invalid value; expected string