### PR TITLE
`xs2a-adapter-service-api` - add setter for PaymentInitiationAuthorisationResponse.authorisationIds

### DIFF
--- a/xs2a-adapter-service-api/src/main/java/de/adorsys/xs2a/adapter/service/model/PaymentInitiationAuthorisationResponse.java
+++ b/xs2a-adapter-service-api/src/main/java/de/adorsys/xs2a/adapter/service/model/PaymentInitiationAuthorisationResponse.java
@@ -15,4 +15,8 @@ public class PaymentInitiationAuthorisationResponse {
     public List<String> getAuthorisationIds() {
         return authorisationIds;
     }
+
+    public void setAuthorisationIds(List<String> authorisationIds) {
+        this.authorisationIds = authorisationIds;
+    }
 }


### PR DESCRIPTION
Without setter mapstruct will not copy 'authorisationIds' list to PaymentInitiationAuthorisationResponse from AuthorisationsTO because 'authorisationIds' is null on target.