### PR TITLE
Fix bank-verlag's "DHPublicKey does not comply to algorithm constraints"

### DIFF
--- a/adapters/verlag-adapter/src/main/java/de/adorsys/xs2a/adapter/service/provider/VerlagServiceProvider.java
+++ b/adapters/verlag-adapter/src/main/java/de/adorsys/xs2a/adapter/service/provider/VerlagServiceProvider.java
@@ -30,6 +30,8 @@ public class VerlagServiceProvider implements AccountInformationServiceProvider,
 
     private static final String VERLAG_API_KEY_NAME = "verlag.apikey.name";
     private static final String VERLAG_API_KEY_VALUE = "verlag.apikey.value";
+    private static final String[] SUPPORTED_CIPHER_SUITES =
+        {"TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384", "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"};
 
     private static AbstractMap.SimpleImmutableEntry<String, String> apiKeyEntry;
 
@@ -43,14 +45,14 @@ public class VerlagServiceProvider implements AccountInformationServiceProvider,
     public AccountInformationService getAccountInformationService(String baseUrl, HttpClientFactory httpClientFactory, Pkcs12KeyStore keyStore) {
         return new VerlagAccountInformationService(baseUrl,
             apiKeyEntry,
-            httpClientFactory.getHttpClient(getAdapterId()));
+            httpClientFactory.getHttpClient(getAdapterId(), null, SUPPORTED_CIPHER_SUITES));
     }
 
     @Override
     public PaymentInitiationService getPaymentInitiationService(String baseUrl, HttpClientFactory httpClientFactory, Pkcs12KeyStore keyStore) {
         return new VerlagPaymentInitiationService(baseUrl,
             apiKeyEntry,
-            httpClientFactory.getHttpClient(getAdapterId()));
+            httpClientFactory.getHttpClient(getAdapterId(), null, SUPPORTED_CIPHER_SUITES));
     }
 
     @Override

--- a/xs2a-adapter-service-api-adapter/src/test/java/de/adorsys/xs2a/adapter/http/ApacheHttpClientFactoryTest.java
+++ b/xs2a-adapter-service-api-adapter/src/test/java/de/adorsys/xs2a/adapter/http/ApacheHttpClientFactoryTest.java
@@ -5,17 +5,23 @@ import org.apache.http.impl.client.HttpClientBuilder;
 import org.junit.Before;
 import org.junit.Test;
 
+import javax.net.ssl.SSLContext;
+
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class ApacheHttpClientFactoryTest {
 
     private ApacheHttpClientFactory factory;
 
     @Before
-    public void setUp() {
-        Pkcs12KeyStore mock = mock(Pkcs12KeyStore.class);
-        factory = new ApacheHttpClientFactory(HttpClientBuilder.create(), mock);
+    public void setUp() throws Exception {
+        Pkcs12KeyStore pkcs12KeyStore = mock(Pkcs12KeyStore.class);
+        when(pkcs12KeyStore.getSslContext(any()))
+            .thenReturn(SSLContext.getDefault());
+        factory = new ApacheHttpClientFactory(HttpClientBuilder.create(), pkcs12KeyStore);
     }
 
     @Test

--- a/xs2a-adapter-service-api/src/main/java/de/adorsys/xs2a/adapter/http/HttpClientFactory.java
+++ b/xs2a-adapter-service-api/src/main/java/de/adorsys/xs2a/adapter/http/HttpClientFactory.java
@@ -1,7 +1,11 @@
 package de.adorsys.xs2a.adapter.http;
 
 public interface HttpClientFactory {
-    HttpClient getHttpClient(String adapterId, String qwacAlias);
+    HttpClient getHttpClient(String adapterId, String qwacAlias, String[] supportedCipherSuites);
+
+    default HttpClient getHttpClient(String adapterId, String qwacAlias) {
+        return getHttpClient(adapterId, qwacAlias, null);
+    }
 
     default HttpClient getHttpClient(String adapterId) {
         return getHttpClient(adapterId, null);


### PR DESCRIPTION
TLS handshake with production server of bank-verlag fails because Diffie-Hellman
key length is 1024 bits. While minimum recommended is 2048.
The server also ranks DHE key exchange algorithm above ECDHE that stronger.
As a solution limit supported cipher suites of the client to strong cipher suites
supported by production and sandbox servers.