### PR TITLE
`xs2a-adapter-rest-impl` - ErrorResponse - add @JsonIgnore to 'isEmpty' method because "empty" property is returned in response JSON, e.g.:

### DIFF
--- a/xs2a-adapter-service-api/src/main/java/de/adorsys/xs2a/adapter/service/model/ErrorResponse.java
+++ b/xs2a-adapter-service-api/src/main/java/de/adorsys/xs2a/adapter/service/model/ErrorResponse.java
@@ -1,5 +1,6 @@
 package de.adorsys.xs2a.adapter.service.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.List;
@@ -39,6 +40,7 @@ public class ErrorResponse {
         this.links = links;
     }
 
+    @JsonIgnore
     public boolean isEmpty() {
         return tppMessages == null && links == null;
     }


### PR DESCRIPTION
```json
{
  "tppMessages" : [ {
    "category" : "ERROR",
    "code" : "BAD_REQUEST",
    "text" : "Consent with empty access/accounts not supported."
  } ],
  "empty" : false
}
```