### PR TITLE
Change csv file digest algorithm from md5 to sha-256

### DIFF
--- a/xs2a-adapter-aspsp-registry/src/main/java/de/adorsys/xs2a/adapter/registry/LuceneAspspRepositoryFactory.java
+++ b/xs2a-adapter-aspsp-registry/src/main/java/de/adorsys/xs2a/adapter/registry/LuceneAspspRepositoryFactory.java
@@ -43,13 +43,13 @@ public class LuceneAspspRepositoryFactory {
 
         MessageDigest messageDigest = null;
         try {
-            messageDigest = MessageDigest.getInstance("MD5");
+            messageDigest = MessageDigest.getInstance("SHA-256");
         } catch (NoSuchAlgorithmException e) {
             throw new RuntimeException(e);
         }
         String computedDigest = new BigInteger(1, messageDigest.digest(csv)).toString(16);
 
-        Path digestPath = Paths.get(DEFAULT_LUCENE_DIR_PATH, "digest.md5");
+        Path digestPath = Paths.get(DEFAULT_LUCENE_DIR_PATH, "digest.sha256");
         boolean changed;
         if (Files.exists(digestPath)) {
             String storedDigest = new String(Files.readAllBytes(digestPath));


### PR DESCRIPTION
MD5 is no longer required since Java 14
https://github.com/openjdk/jdk/commit/b171594072659cd9914c0f211156f4af3e2b0550#diff-7de55d11c146a664ea77257279945551