### PR TITLE
Remove sparda code verifier length change from release notes

### DIFF
--- a/docs/release_notes/DRAFT_Release_notes_0.0.9.adoc
+++ b/docs/release_notes/DRAFT_Release_notes_0.0.9.adoc
@@ -23,4 +23,3 @@ See https://github.com/adorsys/xs2a-adapter/issues/348[#348]
 - Added payment initiation service to psd2 api.
 
 == Fixes:
-- `code_verifier` parameter minimum length lowered to 43 characters in sparda adapter.


### PR DESCRIPTION
Was raised back to 44 by the previous commit.