### PR TITLE
Add dummy banks for process miner development

### DIFF
--- a/xs2a-adapter-aspsp-registry/src/main/resources/aspsp-adapter-config.csv
+++ b/xs2a-adapter-aspsp-registry/src/main/resources/aspsp-adapter-config.csv
@@ -1,1 +1,5 @@
 53c47f54-b9a4-465a-8f77-bc6cd5f0cf46,adorsys xs2a,ADORSYS,https://amos-modelbank-xs2a.cloud.adorsys.de,adorsys-integ-adapter,99999999
+2dfd45da-64cd-4023-94a5-671f664b5eec,Bank Of Alpha,ALPHA,https://amos-modelbank-xs2a.cloud.adorsys.de,adorsys-integ-adapter,11111111
+6a261ed8-a2bc-4146-a16d-dfcea10b0687,Beta‘s Bank,BETA,https://amos-modelbank-xs2a.cloud.adorsys.de,adorsys-integ-adapter,22222222
+893c202e-8f3b-4f34-87c1-8f794726b7f0,Royal Gamma Bank,GAMMA,https://amos-modelbank-xs2a.cloud.adorsys.de,adorsys-integ-adapter,33333333
+9e0b84e8-8087-4d75-aa31-656fb1f92826,Delta National Bank,DELTA,https://amos-modelbank-xs2a.cloud.adorsys.de,adorsys-integ-adapter,44444444


### PR DESCRIPTION
The AMOS-Project needs additional banks to simulate different scenarios while developing the process miner.
The UUIDs were created using `uuidgen`. If there is anything that has to be adjusted just let me know.