### PR TITLE
Suppress hashing security hotspots detected by sonar

### DIFF
--- a/adapters/ing-adapter/src/main/java/de/adorsys/xs2a/adapter/ing/IngClientAuthenticationFactory.java
+++ b/adapters/ing-adapter/src/main/java/de/adorsys/xs2a/adapter/ing/IngClientAuthenticationFactory.java
@@ -14,6 +14,7 @@ public class IngClientAuthenticationFactory {
     private final String tppSignatureCertificate;
     private final String keyId;
 
+    @SuppressWarnings("java:S4790")
     public IngClientAuthenticationFactory(X509Certificate certificate, PrivateKey privateKey) throws NoSuchAlgorithmException, InvalidKeyException, CertificateEncodingException {
         signature = Signature.getInstance("SHA256withRSA");
         signature.initSign(privateKey);

--- a/xs2a-adapter-aspsp-registry/src/main/java/de/adorsys/xs2a/adapter/registry/LuceneAspspRepositoryFactory.java
+++ b/xs2a-adapter-aspsp-registry/src/main/java/de/adorsys/xs2a/adapter/registry/LuceneAspspRepositoryFactory.java
@@ -44,12 +44,7 @@ public class LuceneAspspRepositoryFactory {
         LuceneAspspRepository luceneAspspRepository = new LuceneAspspRepository(directory);
         byte[] csv = getCsvFileAsByteArray();
 
-        MessageDigest messageDigest = null;
-        try {
-            messageDigest = MessageDigest.getInstance("SHA-256");
-        } catch (NoSuchAlgorithmException e) {
-            throw new Xs2aAdapterException(e);
-        }
+        MessageDigest messageDigest = getMessageDigest();
         String computedDigest = new BigInteger(1, messageDigest.digest(csv)).toString(16);
 
         Path digestPath = Paths.get(luceneDirPath, "digest.sha256");
@@ -70,6 +65,17 @@ public class LuceneAspspRepositoryFactory {
             Files.write(digestPath, computedDigest.getBytes());
         }
         return luceneAspspRepository;
+    }
+
+    @SuppressWarnings("java:S4790") // hashing is not used in security context
+    private MessageDigest getMessageDigest() {
+        MessageDigest messageDigest;
+        try {
+            messageDigest = MessageDigest.getInstance("SHA-256");
+        } catch (NoSuchAlgorithmException e) {
+            throw new Xs2aAdapterException(e);
+        }
+        return messageDigest;
     }
 
     private byte[] getCsvFileAsByteArray() {

--- a/xs2a-adapter-service-api-adapter/src/main/java/de/adorsys/xs2a/adapter/signing/service/hashing/AbstractShaHashingService.java
+++ b/xs2a-adapter-service-api-adapter/src/main/java/de/adorsys/xs2a/adapter/signing/service/hashing/AbstractShaHashingService.java
@@ -9,6 +9,7 @@ import java.security.NoSuchAlgorithmException;
 
 public abstract class AbstractShaHashingService implements HashingService {
 
+    @SuppressWarnings("java:S4790")
     @Override
     public byte[] hash(String data, Charset charset) {
         try {

--- a/xs2a-adapter-service-api/src/main/java/de/adorsys/xs2a/adapter/service/PkceOauth2Extension.java
+++ b/xs2a-adapter-service-api/src/main/java/de/adorsys/xs2a/adapter/service/PkceOauth2Extension.java
@@ -35,6 +35,7 @@ public interface PkceOauth2Extension {
         return base64urlNoPadding(sha256(codeVerifier().getBytes()));
     }
 
+    @SuppressWarnings("java:S4790")
     static byte[] sha256(byte[] bytes) {
         try {
             return MessageDigest.getInstance("SHA-256").digest(bytes);


### PR DESCRIPTION
https://rules.sonarsource.com/java/RSPEC-4790
Hashing is performed according to the specification of a standard
(pkce/request signature) or used in non-security related context.