### PR TITLE
Document csv and properties file dependencies in the Building Block View

### DIFF
--- a/docs/arc42/puml/whitebox_lv1_library.puml
+++ b/docs/arc42/puml/whitebox_lv1_library.puml
@@ -2,27 +2,34 @@
 
 title WhiteBox Level 1
 
-collections banks as "Banks"
+interface bxs2a as "XS2A Services"
+collections banks as "ASPSPs"
 
-interface "xs2a" as bhttp
+rectangle "xs2a-adapter (library)" {
+    interface axs2a as "Adapted XS2A Services"
+    component api as "service-api"
+    interface aspsp_repo as "AspspReadOnlyRepository"
+    component registry as "aspsp-registry"
+    component impl as "service-impl"
+    component serviceloader as "service-loader"
+    collections adapters as "adapters"
+    file csv as "aspsp-adapter-config.csv"
+    file conf as "adapter.config.properties"
 
-rectangle xa as "xs2a adapter as library" {
-	component ar as "aspsp-registry"
-	component sa as "service-api"
-	component saa as "service-api-adapter"
-	component sl as "service-loader"
+    api <- impl
+    impl <- adapters
+    adapters -( bxs2a
+    bxs2a - banks
 
-	collections ba as "bank adapters"
+    registry -right- aspsp_repo
+    api <-- registry
+    api <-- serviceloader
+    adapters -- axs2a
+    adapters <.. serviceloader: delegatesTo
+    serviceloader -- axs2a
+    serviceloader -left( aspsp_repo
+
+    registry --> csv
+    api --> conf
 }
-
-	sl --> ar
-	sl --> ba
-	sa -0)- sl: AIS, PIS, oAuth, download API
-	ba --> saa
-	ba -(0- sa: AIS, PIS, oAuth, download API
-	ar -(0-sa: aspsp search
-
-	ba -( bhttp: http
-	banks --() bhttp
-
 @enduml

--- a/docs/arc42/puml/whitebox_lv1_stanalone.puml
+++ b/docs/arc42/puml/whitebox_lv1_stanalone.puml
@@ -12,13 +12,13 @@ rectangle tpp1 as "TPP1" {
 
 rectangle tpp2 <<TPP2>> as "TPP2"
 
-collections banks as "Banks"
+collections banks as "ASPSPs"
 
 interface "xs2a" as ahttp
 
 interface "xs2a" as bhttp
 
-rectangle xa as "xs2a adapter as standalone  application" {
+rectangle "xs2a-adapter (standalone)" {
     component sr as "service-remote"
 	component ar as "aspsp-registry"
 	component gra as "generated-rest-api"
@@ -27,10 +27,10 @@ rectangle xa as "xs2a adapter as standalone  application" {
 	component ra as "rest-api"
 	component ri as "rest-impl"
 	component sa as "service-api"
-	component saa as "service-api-adapter"
+	component si as "service-impl"
 	component sl as "service-loader"
 
-	collections ba as "bank adapters"
+	collections ba as "adapters"
 }
 
 	sl --> ar
@@ -44,7 +44,7 @@ rectangle xa as "xs2a adapter as standalone  application" {
 	ri -(0- ra
 	ri -> sa
 	sr --> r2am
-	ba -> saa
+	ba -> si
 	ba -(0- sa: AIS, PIS, oAuth, download API
 	ri --() ahttp
 	tpp2 -( ahttp: http

--- a/docs/arc42/sections/5_building_block_view.adoc
+++ b/docs/arc42/sections/5_building_block_view.adoc
@@ -9,10 +9,10 @@ image::whitebox_lv1_library.png[5.1. Whitebox XS2A Adapter library,width=520]
 |===
 |Building block |Description
 |service-api |Payment initiation, account information, http client and validation interfaces
-|service-api-adapter |Basic implementation of payment initiation and account information, implementation of http client
+|service-impl |Basic implementation of payment initiation and account information, implementation of http client
 |service-loader |Load payment initiation or account information service implementation for specific adapter
 |aspsp-registry |Registry of supported banks. Each record contains bank details and reference to the adapter
-|bank adapters |Collection of bank adapters supported by XS2A Adapter
+|adapters |Collection of bank adapters supported by XS2A Adapter
 |===
 
 ==== 5.1.1. Whitebox XS2A Adapter Standalone
@@ -24,10 +24,10 @@ image::whitebox_lv1_stanalone.png[5.1.1. Whitebox XS2A Adapter Standalone,width=
 |===
 |Building block |Description
 |service-api |Payment initiation, account information, http client and validation interfaces
-|service-api-adapter |Basic implementation of payment initiation and account information, implementation of http client
+|service-impl |Basic implementation of payment initiation and account information, implementation of http client
 |service-loader |Load payment initiation or account information service implementation for specific adapter
 |aspsp-registry |Registry of supported banks. Each record contains bank details and reference to the adapter
-|bank adapters |Collection of bank adapters supported by XS2A Adapter
+|adapters |Collection of bank adapters supported by XS2A Adapter
 |rest-api |ASPSP Registry REST API, OAuth REST API
 |rest2api-mapper |Mappers between rest and service layers
 |generated-rest-api |Generated REST API from Berlin Group yml specification


### PR DESCRIPTION
Also updated the rest of the library component diagram according to the
conventional meaning of the ball and socket notation.
> symbols with a complete circle at their end represent an interface
> that the component provides — this “lollipop” symbol is shorthand for
> a realization relationship of an interface classifier. Interface
> symbols with only a half circle at their end (a.k.a. sockets)
> represent an interface that the component requires (in both cases, the
> interface’s name is placed near the interface symbol itself).
> - https://developer.ibm.com/articles/the-component-diagram/

And renamed component labels:
 * "service-api-adapter" to "service-impl";
 * "bank adapters" to "adapters": matching the maven module name;
 * "Banks" to "ASPSPs": consistent terminology with aspsp-registry.