### PR TITLE
Remove PFB business entity support in db adapter

### DIFF
--- a/adapters/deutsche-bank-adapter/src/main/java/de/adorsys/xs2a/adapter/deutschebank/PsuIdTypeHeaderInterceptor.java
+++ b/adapters/deutsche-bank-adapter/src/main/java/de/adorsys/xs2a/adapter/deutschebank/PsuIdTypeHeaderInterceptor.java
@@ -32,8 +32,7 @@ public class PsuIdTypeHeaderInterceptor implements Request.Builder.Interceptor {
         String countryCode = path.getName(1).toString();
         if ("DE".equals(countryCode)) {
             String businessEntity = path.getName(2).toString();
-            // https://jira.adorsys.de/browse/XS2AAD-669
-            if ("DB".equals(businessEntity) || "PFB".equals(businessEntity)) {
+            if ("DB".equals(businessEntity)) {
                 builder.header(RequestHeaders.PSU_ID_TYPE, "DE_ONLB_DB");
             } else if ("Postbank".equals(businessEntity)) {
                 builder.header(RequestHeaders.PSU_ID_TYPE, "DE_ONLB_POBA");

--- a/adapters/deutsche-bank-adapter/src/test/java/de/adorsys/xs2a/adapter/deutschebank/PsuIdTypeHeaderInterceptorTest.java
+++ b/adapters/deutsche-bank-adapter/src/test/java/de/adorsys/xs2a/adapter/deutschebank/PsuIdTypeHeaderInterceptorTest.java
@@ -28,13 +28,6 @@ class PsuIdTypeHeaderInterceptorTest {
     }
 
     @Test
-    void setsPsuIdTypeForPfbBusinessEntityInGermanyWhenPsuIdIsPresent() {
-        builder.uri("https://xs2a.db.com/ais/DE/PFB");
-        Request.Builder actual = interceptor.apply(builder);
-        assertEquals("DE_ONLB_DB", actual.headers().get(RequestHeaders.PSU_ID_TYPE));
-    }
-
-    @Test
     void doesNothingWhenPsuIdIsNotSet() {
         builder.uri("https://xs2a.db.com/ais/DE/DB");
         builder.headers().remove(RequestHeaders.PSU_ID);

--- a/docs/release_notes/DRAFT_Release_notes_0.1.3.adoc
+++ b/docs/release_notes/DRAFT_Release_notes_0.1.3.adoc
@@ -6,6 +6,8 @@
 
 == Notices:
 - Removed deprecated methods in `PaymentInitiationService` and `PaymentInitiationValidationService`.
+- Removed PFB business entity support in deutsche bank adapter.
+See the previous release notes for more details.
 
 == Features:
 


### PR DESCRIPTION
Completes the migration started in the previous release.