### PR TITLE
Set Accept header for get transactions, consors

### DIFF
--- a/adapters/consors-bank-adapter/src/main/java/de/adorsys/xs2a/adapter/consors/ConsorsAccountInformationService.java
+++ b/adapters/consors-bank-adapter/src/main/java/de/adorsys/xs2a/adapter/consors/ConsorsAccountInformationService.java
@@ -37,6 +37,14 @@ public class ConsorsAccountInformationService extends BaseAccountInformationServ
     }
 
     @Override
+    public Response<String> getTransactionListAsString(String accountId,
+                                                       RequestHeaders requestHeaders,
+                                                       RequestParams requestParams) {
+        return getTransactionList(accountId, requestHeaders, requestParams)
+            .map(jsonMapper::writeValueAsString);
+    }
+
+    @Override
     public Response<OK200TransactionDetails> getTransactionDetails(String accountId,
                                                                    String transactionId,
                                                                    RequestHeaders requestHeaders,

--- a/adapters/consors-bank-adapter/src/test/java/de/adorsys/xs2a/adapter/consors/ConsorsAccountInformationServiceTest.java
+++ b/adapters/consors-bank-adapter/src/test/java/de/adorsys/xs2a/adapter/consors/ConsorsAccountInformationServiceTest.java
@@ -1,9 +1,11 @@
 package de.adorsys.xs2a.adapter.consors;
 
 import de.adorsys.xs2a.adapter.api.*;
+import de.adorsys.xs2a.adapter.api.http.ContentType;
 import de.adorsys.xs2a.adapter.api.http.HttpClient;
 import de.adorsys.xs2a.adapter.api.http.Request;
 import de.adorsys.xs2a.adapter.api.model.*;
+import de.adorsys.xs2a.adapter.consors.model.ConsorsTransactionsResponse200Json;
 import de.adorsys.xs2a.adapter.impl.http.AbstractHttpClient;
 import de.adorsys.xs2a.adapter.impl.link.identity.IdentityLinksRewriter;
 import org.junit.jupiter.api.BeforeEach;
@@ -145,5 +147,18 @@ class ConsorsAccountInformationServiceTest {
         assertThat(actualHeaders)
             .isNotEmpty()
             .containsEntry(PSU_ID, "");
+    }
+
+    @Test
+    void getTransactionSetsAcceptApplicationJson() {
+        Mockito.when(httpClient.send(Mockito.any(), Mockito.any()))
+            .thenReturn(new Response<>(200, new ConsorsTransactionsResponse200Json(), ResponseHeaders.emptyResponseHeaders()));
+
+        service.getTransactionListAsString(null, RequestHeaders.empty(), RequestParams.empty());
+
+        Mockito.verify(httpClient, Mockito.times(1))
+            .send(builderCaptor.capture(), Mockito.any());
+        assertThat(builderCaptor.getValue().headers())
+            .containsEntry(RequestHeaders.ACCEPT, ContentType.APPLICATION_JSON);
     }
 }

--- a/docs/release_notes/DRAFT_Release_notes_0.1.3.adoc
+++ b/docs/release_notes/DRAFT_Release_notes_0.1.3.adoc
@@ -13,4 +13,8 @@ See the previous release notes for more details.
 == Features:
 
 == Fixes:
+- 406 error response from consors on get transactions with `Accept` set to any (\*/*)
+[quote]
+The requested formats in the Accept header entry are not matching the formats offered by the ASPSP
+
 


### PR DESCRIPTION
> Accept header is mandatory, and the only accepted value is "application/json"
> - https://www.consorsbank.de/content/dam/de-cb/editorial/PDF/Service-Beratung/xs2a/xs2a-nextgen-psd2-framework-20200909.yaml