### PR TITLE
added CrealogixValidationResponse model for DKB 

### DIFF
--- a/adapters/crealogix-adapter/src/main/java/de/adorsys/xs2a/adapter/crealogix/CrealogixMapper.java
+++ b/adapters/crealogix-adapter/src/main/java/de/adorsys/xs2a/adapter/crealogix/CrealogixMapper.java
@@ -1,10 +1,7 @@
 package de.adorsys.xs2a.adapter.crealogix;
 
 import de.adorsys.xs2a.adapter.api.model.*;
-import de.adorsys.xs2a.adapter.crealogix.model.CrealogixOK200TransactionDetails;
-import de.adorsys.xs2a.adapter.crealogix.model.CrealogixPaymentInitiationWithStatusResponse;
-import de.adorsys.xs2a.adapter.crealogix.model.CrealogixTransactionDetails;
-import de.adorsys.xs2a.adapter.crealogix.model.CrealogixTransactionResponse200Json;
+import de.adorsys.xs2a.adapter.crealogix.model.*;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 
@@ -15,6 +12,7 @@ public interface CrealogixMapper {
     TransactionsResponse200Json toTransactionsResponse200Json(CrealogixTransactionResponse200Json value);
     OK200TransactionDetails toOK200TransactionDetails(CrealogixOK200TransactionDetails value);
     Transactions toTransactions(CrealogixTransactionDetails value);
+    TokenResponse toTokenResponse(CrealogixValidationResponse value);
 
     @Mapping(target = "transactionDetails", expression = "java(toTransactions(value))")
     TransactionDetailsBody toTransactionDetailsBody(CrealogixTransactionDetails value);

--- a/adapters/crealogix-adapter/src/main/java/de/adorsys/xs2a/adapter/crealogix/model/CrealogixActionCode.java
+++ b/adapters/crealogix-adapter/src/main/java/de/adorsys/xs2a/adapter/crealogix/model/CrealogixActionCode.java
@@ -1,36 +1,20 @@
 package de.adorsys.xs2a.adapter.crealogix.model;
 
+import java.util.stream.Stream;
+
 public enum CrealogixActionCode {
-    PROMPT_FOR_LOGIN_NAME_PASSWORD("PROMPT_FOR_LOGIN_NAME_PASSWORD"),
-    PROMPT_FOR_AUTH_METHOD_SELECTION("PROMPT_FOR_AUTH_METHOD_SELECTION"),
-    PROMPT_FOR_TAN("PROMPT_FOR_TAN"),
-    POLL_FOR_TAN("POLL_FOR_TAN"),
-    STOP_POLL_FOR_TAN("STOP_POLL_FOR_TAN"),
-    PROMPT_FOR_PASSWORD_CHANGE("PROMPT_FOR_PASSWORD_CHANGE"),
-    PROMPT_FOR_SCOPE_ACCEPTANCE("PROMPT_FOR_SCOPE_ACCEPTANCE"),
-    SEND_REQUEST("SEND_REQUEST");
-
-    private String value;
-
-    CrealogixActionCode(String value) {
-        this.value = value;
-    }
-
-    public String getValue() {
-        return value;
-    }
-
-    @Override
-    public String toString() {
-        return String.valueOf(value);
-    }
+    PROMPT_FOR_LOGIN_NAME_PASSWORD,
+    PROMPT_FOR_AUTH_METHOD_SELECTION,
+    PROMPT_FOR_TAN,
+    POLL_FOR_TAN,
+    STOP_POLL_FOR_TAN,
+    PROMPT_FOR_PASSWORD_CHANGE,
+    PROMPT_FOR_SCOPE_ACCEPTANCE,
+    SEND_REQUEST;
 
     public static CrealogixActionCode fromValue(String text) {
-        for (CrealogixActionCode b : CrealogixActionCode.values()) {
-            if (String.valueOf(b.value).equals(text)) {
-                return b;
-            }
-        }
-        return null;
+        return Stream.of(CrealogixActionCode.values())
+            .filter(c -> c.name().equalsIgnoreCase(text))
+            .findFirst().orElse(null);
     }
 }

--- a/adapters/crealogix-adapter/src/main/java/de/adorsys/xs2a/adapter/crealogix/model/CrealogixActionCode.java
+++ b/adapters/crealogix-adapter/src/main/java/de/adorsys/xs2a/adapter/crealogix/model/CrealogixActionCode.java
@@ -1,0 +1,36 @@
+package de.adorsys.xs2a.adapter.crealogix.model;
+
+public enum CrealogixActionCode {
+    PROMPT_FOR_LOGIN_NAME_PASSWORD("PROMPT_FOR_LOGIN_NAME_PASSWORD"),
+    PROMPT_FOR_AUTH_METHOD_SELECTION("PROMPT_FOR_AUTH_METHOD_SELECTION"),
+    PROMPT_FOR_TAN("PROMPT_FOR_TAN"),
+    POLL_FOR_TAN("POLL_FOR_TAN"),
+    STOP_POLL_FOR_TAN("STOP_POLL_FOR_TAN"),
+    PROMPT_FOR_PASSWORD_CHANGE("PROMPT_FOR_PASSWORD_CHANGE"),
+    PROMPT_FOR_SCOPE_ACCEPTANCE("PROMPT_FOR_SCOPE_ACCEPTANCE"),
+    SEND_REQUEST("SEND_REQUEST");
+
+    private String value;
+
+    CrealogixActionCode(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    public static CrealogixActionCode fromValue(String text) {
+        for (CrealogixActionCode b : CrealogixActionCode.values()) {
+            if (String.valueOf(b.value).equals(text)) {
+                return b;
+            }
+        }
+        return null;
+    }
+}

--- a/adapters/crealogix-adapter/src/main/java/de/adorsys/xs2a/adapter/crealogix/model/CrealogixAuthItem.java
+++ b/adapters/crealogix-adapter/src/main/java/de/adorsys/xs2a/adapter/crealogix/model/CrealogixAuthItem.java
@@ -1,0 +1,50 @@
+package de.adorsys.xs2a.adapter.crealogix.model;
+
+import java.util.Objects;
+
+public class CrealogixAuthItem {
+    private String authOptionId;
+
+    private CrealogixAuthType authType;
+
+    private String authInfo;
+
+    public String getAuthOptionId() {
+        return authOptionId;
+    }
+
+    public void setAuthOptionId(String authOptionId) {
+        this.authOptionId = authOptionId;
+    }
+
+    public CrealogixAuthType getAuthType() {
+        return authType;
+    }
+
+    public void setAuthType(CrealogixAuthType authType) {
+        this.authType = authType;
+    }
+
+    public String getAuthInfo() {
+        return authInfo;
+    }
+
+    public void setAuthInfo(String authInfo) {
+        this.authInfo = authInfo;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        CrealogixAuthItem that = (CrealogixAuthItem) o;
+        return Objects.equals(authOptionId, that.authOptionId) &&
+            authType == that.authType &&
+            Objects.equals(authInfo, that.authInfo);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(authOptionId, authType, authInfo);
+    }
+}

--- a/adapters/crealogix-adapter/src/main/java/de/adorsys/xs2a/adapter/crealogix/model/CrealogixAuthType.java
+++ b/adapters/crealogix-adapter/src/main/java/de/adorsys/xs2a/adapter/crealogix/model/CrealogixAuthType.java
@@ -1,35 +1,19 @@
 package de.adorsys.xs2a.adapter.crealogix.model;
 
+import java.util.stream.Stream;
+
 public enum CrealogixAuthType {
-    PASSWORD("PASSWORD"),
-    SMSTAN("SMSTAN"),
-    MATRIX("MATRIX"),
-    FOTOTAN("FOTOTAN"),
-    PUSHTAN("PUSHTAN"),
-    DIGIPASS("DIGIPASS"),
-    CHIPTAN("CHIPTAN");
-
-    private String value;
-
-    CrealogixAuthType(String value) {
-        this.value = value;
-    }
-
-    public String getValue() {
-        return value;
-    }
-
-    @Override
-    public String toString() {
-        return String.valueOf(value);
-    }
+    PASSWORD,
+    SMSTAN,
+    MATRIX,
+    FOTOTAN,
+    PUSHTAN,
+    DIGIPASS,
+    CHIPTAN;
 
     public static CrealogixAuthType fromValue(String text) {
-        for (CrealogixAuthType b : CrealogixAuthType.values()) {
-            if (String.valueOf(b.value).equals(text)) {
-                return b;
-            }
-        }
-        return null;
+        return Stream.of(CrealogixAuthType.values())
+            .filter(t -> t.name().equalsIgnoreCase(text))
+            .findFirst().orElse(null);
     }
 }

--- a/adapters/crealogix-adapter/src/main/java/de/adorsys/xs2a/adapter/crealogix/model/CrealogixAuthType.java
+++ b/adapters/crealogix-adapter/src/main/java/de/adorsys/xs2a/adapter/crealogix/model/CrealogixAuthType.java
@@ -1,0 +1,35 @@
+package de.adorsys.xs2a.adapter.crealogix.model;
+
+public enum CrealogixAuthType {
+    PASSWORD("PASSWORD"),
+    SMSTAN("SMSTAN"),
+    MATRIX("MATRIX"),
+    FOTOTAN("FOTOTAN"),
+    PUSHTAN("PUSHTAN"),
+    DIGIPASS("DIGIPASS"),
+    CHIPTAN("CHIPTAN");
+
+    private String value;
+
+    CrealogixAuthType(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    public static CrealogixAuthType fromValue(String text) {
+        for (CrealogixAuthType b : CrealogixAuthType.values()) {
+            if (String.valueOf(b.value).equals(text)) {
+                return b;
+            }
+        }
+        return null;
+    }
+}

--- a/adapters/crealogix-adapter/src/main/java/de/adorsys/xs2a/adapter/crealogix/model/CrealogixReturnCode.java
+++ b/adapters/crealogix-adapter/src/main/java/de/adorsys/xs2a/adapter/crealogix/model/CrealogixReturnCode.java
@@ -1,0 +1,45 @@
+package de.adorsys.xs2a.adapter.crealogix.model;
+
+public enum CrealogixReturnCode {
+    NONE("NONE"),
+    CORRECT("CORRECT"),
+    CORRECT_PASSWORD_CHANGE("CORRECT_PASSWORD_CHANGE"),
+    FAILED("FAILED"),
+    LOCKED("LOCKED"),
+    TEMPORARY_LOCKED("TEMPORARY_LOCKED"),
+    PASSWORD_EXPIRED("PASSWORD_EXPIRED"),
+    OFFLINE_TOOL_ONLY("OFFLINE_TOOL_ONLY"),
+    NO_SUITABLE_AUTHENTICATION_TYPE("NO_SUITABLE_AUTHENTICATION_TYPE"),
+    TAN_WRONG("TAN_WRONG"),
+    TAN_INVALIDATED("TAN_INVALIDATED"),
+    TAN_EXPIRED("TAN_EXPIRED"),
+    TAN_NOT_ACTIVE("TAN_NOT_ACTIVE"),
+    NOTIFICATION_UNDELIVERABLE("NOTIFICATION_UNDELIVERABLE"),
+    NOTIFICATION_CONFIRMATION_REJECTED("NOTIFICATION_CONFIRMATION_REJECTED"),
+    NOTIFICATION_EXPIRED("NOTIFICATION_EXPIRED"),
+    AWAITING_USER_RESPONSE("AWAITING_USER_RESPONSE");
+
+    private String value;
+
+    CrealogixReturnCode(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    public static CrealogixReturnCode fromValue(String text) {
+        for (CrealogixReturnCode b : CrealogixReturnCode.values()) {
+            if (String.valueOf(b.value).equals(text)) {
+                return b;
+            }
+        }
+        return null;
+    }
+}

--- a/adapters/crealogix-adapter/src/main/java/de/adorsys/xs2a/adapter/crealogix/model/CrealogixReturnCode.java
+++ b/adapters/crealogix-adapter/src/main/java/de/adorsys/xs2a/adapter/crealogix/model/CrealogixReturnCode.java
@@ -1,45 +1,29 @@
 package de.adorsys.xs2a.adapter.crealogix.model;
 
+import java.util.stream.Stream;
+
 public enum CrealogixReturnCode {
-    NONE("NONE"),
-    CORRECT("CORRECT"),
-    CORRECT_PASSWORD_CHANGE("CORRECT_PASSWORD_CHANGE"),
-    FAILED("FAILED"),
-    LOCKED("LOCKED"),
-    TEMPORARY_LOCKED("TEMPORARY_LOCKED"),
-    PASSWORD_EXPIRED("PASSWORD_EXPIRED"),
-    OFFLINE_TOOL_ONLY("OFFLINE_TOOL_ONLY"),
-    NO_SUITABLE_AUTHENTICATION_TYPE("NO_SUITABLE_AUTHENTICATION_TYPE"),
-    TAN_WRONG("TAN_WRONG"),
-    TAN_INVALIDATED("TAN_INVALIDATED"),
-    TAN_EXPIRED("TAN_EXPIRED"),
-    TAN_NOT_ACTIVE("TAN_NOT_ACTIVE"),
-    NOTIFICATION_UNDELIVERABLE("NOTIFICATION_UNDELIVERABLE"),
-    NOTIFICATION_CONFIRMATION_REJECTED("NOTIFICATION_CONFIRMATION_REJECTED"),
-    NOTIFICATION_EXPIRED("NOTIFICATION_EXPIRED"),
-    AWAITING_USER_RESPONSE("AWAITING_USER_RESPONSE");
-
-    private String value;
-
-    CrealogixReturnCode(String value) {
-        this.value = value;
-    }
-
-    public String getValue() {
-        return value;
-    }
-
-    @Override
-    public String toString() {
-        return String.valueOf(value);
-    }
+    NONE,
+    CORRECT,
+    CORRECT_PASSWORD_CHANGE,
+    FAILED,
+    LOCKED,
+    TEMPORARY_LOCKED,
+    PASSWORD_EXPIRED,
+    OFFLINE_TOOL_ONLY,
+    NO_SUITABLE_AUTHENTICATION_TYPE,
+    TAN_WRONG,
+    TAN_INVALIDATED,
+    TAN_EXPIRED,
+    TAN_NOT_ACTIVE,
+    NOTIFICATION_UNDELIVERABLE,
+    NOTIFICATION_CONFIRMATION_REJECTED,
+    NOTIFICATION_EXPIRED,
+    AWAITING_USER_RESPONSE;
 
     public static CrealogixReturnCode fromValue(String text) {
-        for (CrealogixReturnCode b : CrealogixReturnCode.values()) {
-            if (String.valueOf(b.value).equals(text)) {
-                return b;
-            }
-        }
-        return null;
+        return Stream.of(CrealogixReturnCode.values())
+            .filter(c -> c.name().equalsIgnoreCase(text))
+            .findFirst().orElse(null);
     }
 }

--- a/adapters/crealogix-adapter/src/main/java/de/adorsys/xs2a/adapter/crealogix/model/CrealogixValidationResponse.java
+++ b/adapters/crealogix-adapter/src/main/java/de/adorsys/xs2a/adapter/crealogix/model/CrealogixValidationResponse.java
@@ -1,0 +1,143 @@
+package de.adorsys.xs2a.adapter.crealogix.model;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * custom DKB model, that the bank returns for 'Login / Credentials validation' request
+ * i.e. POST /psd2-auth/v1/auth/token
+ */
+public class CrealogixValidationResponse {
+    private CrealogixReturnCode returnCode;
+
+    private CrealogixActionCode actionCode;
+
+    private String returnMsg;
+
+    private String lastSuccessfulLoginTimestamp;
+
+    private String authOptionIdLastUsed;
+
+    private CrealogixAuthType authTypeSelected;
+
+    private String authOptionIdSelected;
+
+    private String challenge;
+
+    private Integer timeout;
+
+    private List<CrealogixAuthItem> authSelectionList;
+
+    private String accessToken;
+
+    public CrealogixReturnCode getReturnCode() {
+        return returnCode;
+    }
+
+    public void setReturnCode(CrealogixReturnCode returnCode) {
+        this.returnCode = returnCode;
+    }
+
+    public CrealogixActionCode getActionCode() {
+        return actionCode;
+    }
+
+    public void setActionCode(CrealogixActionCode actionCode) {
+        this.actionCode = actionCode;
+    }
+
+    public String getReturnMsg() {
+        return returnMsg;
+    }
+
+    public void setReturnMsg(String returnMsg) {
+        this.returnMsg = returnMsg;
+    }
+
+    public String getLastSuccessfulLoginTimestamp() {
+        return lastSuccessfulLoginTimestamp;
+    }
+
+    public void setLastSuccessfulLoginTimestamp(String lastSuccessfulLoginTimestamp) {
+        this.lastSuccessfulLoginTimestamp = lastSuccessfulLoginTimestamp;
+    }
+
+    public String getAuthOptionIdLastUsed() {
+        return authOptionIdLastUsed;
+    }
+
+    public void setAuthOptionIdLastUsed(String authOptionIdLastUsed) {
+        this.authOptionIdLastUsed = authOptionIdLastUsed;
+    }
+
+    public CrealogixAuthType getAuthTypeSelected() {
+        return authTypeSelected;
+    }
+
+    public void setAuthTypeSelected(CrealogixAuthType authTypeSelected) {
+        this.authTypeSelected = authTypeSelected;
+    }
+
+    public String getAuthOptionIdSelected() {
+        return authOptionIdSelected;
+    }
+
+    public void setAuthOptionIdSelected(String authOptionIdSelected) {
+        this.authOptionIdSelected = authOptionIdSelected;
+    }
+
+    public String getChallenge() {
+        return challenge;
+    }
+
+    public void setChallenge(String challenge) {
+        this.challenge = challenge;
+    }
+
+    public Integer getTimeout() {
+        return timeout;
+    }
+
+    public void setTimeout(Integer timeout) {
+        this.timeout = timeout;
+    }
+
+    public List<CrealogixAuthItem> getAuthSelectionList() {
+        return authSelectionList;
+    }
+
+    public void setAuthSelectionList(List<CrealogixAuthItem> authSelectionList) {
+        this.authSelectionList = authSelectionList;
+    }
+
+    public String getAccessToken() {
+        return accessToken;
+    }
+
+    public void setAccessToken(String accessToken) {
+        this.accessToken = accessToken;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        CrealogixValidationResponse that = (CrealogixValidationResponse) o;
+        return Objects.equals(returnCode, that.returnCode) &&
+            Objects.equals(actionCode, that.actionCode) &&
+            Objects.equals(returnMsg, that.returnMsg) &&
+            Objects.equals(lastSuccessfulLoginTimestamp, that.lastSuccessfulLoginTimestamp) &&
+            Objects.equals(authOptionIdLastUsed, that.authOptionIdLastUsed) &&
+            Objects.equals(authTypeSelected, that.authTypeSelected) &&
+            Objects.equals(authOptionIdSelected, that.authOptionIdSelected) &&
+            Objects.equals(challenge, that.challenge) &&
+            Objects.equals(timeout, that.timeout) &&
+            Objects.equals(authSelectionList, that.authSelectionList) &&
+            Objects.equals(accessToken, that.accessToken);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(returnCode, actionCode, returnMsg, lastSuccessfulLoginTimestamp, authOptionIdLastUsed, authTypeSelected, authOptionIdSelected, challenge, timeout, authSelectionList, accessToken);
+    }
+}

--- a/adapters/crealogix-adapter/src/test/java/de/adorsys/xs2a/adapter/crealogix/CrealogixEmbeddedPreAuthorisationServiceTest.java
+++ b/adapters/crealogix-adapter/src/test/java/de/adorsys/xs2a/adapter/crealogix/CrealogixEmbeddedPreAuthorisationServiceTest.java
@@ -12,6 +12,7 @@ import de.adorsys.xs2a.adapter.api.http.Request;
 import de.adorsys.xs2a.adapter.api.model.Aspsp;
 import de.adorsys.xs2a.adapter.api.model.EmbeddedPreAuthorisationRequest;
 import de.adorsys.xs2a.adapter.api.model.TokenResponse;
+import de.adorsys.xs2a.adapter.crealogix.model.CrealogixValidationResponse;
 import de.adorsys.xs2a.adapter.impl.http.BaseHttpClientConfig;
 import de.adorsys.xs2a.adapter.impl.http.Xs2aHttpLogSanitizer;
 import de.adorsys.xs2a.adapter.impl.security.AccessTokenException;
@@ -49,8 +50,8 @@ class CrealogixEmbeddedPreAuthorisationServiceTest {
 
     @Test
     void getToken() throws IOException {
-        Response tppResponse = mock(Response.class);
-        Response psd2Response = mock(Response.class);
+        Response<TokenResponse> tppResponse = mock(Response.class);
+        Response<CrealogixValidationResponse> psd2Response = mock(Response.class);
         TokenResponse tppTokenResponse = new TokenResponse();
         tppTokenResponse.setAccessToken("tpp");
         TokenResponse psd2TokenResponse = new TokenResponse();
@@ -69,6 +70,7 @@ class CrealogixEmbeddedPreAuthorisationServiceTest {
         doReturn(psd2Builder).when(psd2Builder).jsonBody(anyString());
         doReturn(psd2Builder).when(psd2Builder).headers(anyMap());
         doReturn(psd2Response).when(psd2Builder).send(any());
+        doReturn(psd2Response).when(psd2Response).map(any());
         doReturn(psd2TokenResponse).when(psd2Response).getBody();
 
         TokenResponse token = authorisationService.getToken(new EmbeddedPreAuthorisationRequest(), RequestHeaders.fromMap(Collections.emptyMap()));
@@ -87,7 +89,7 @@ class CrealogixEmbeddedPreAuthorisationServiceTest {
         InputStream inputStream = new ByteArrayInputStream(stringBody.getBytes());
 
         TokenResponse actualResponse
-            = authorisationService.responseHandler().apply(statusCode, inputStream, ResponseHeaders.emptyResponseHeaders());
+            = authorisationService.responseHandler(TokenResponse.class).apply(statusCode, inputStream, ResponseHeaders.emptyResponseHeaders());
 
         assertThat(actualResponse)
             .isNotNull()
@@ -97,7 +99,7 @@ class CrealogixEmbeddedPreAuthorisationServiceTest {
     @ParameterizedTest
     @ValueSource(ints = {302, 403, 500})
     void responseHandler_notSuccessfulStatuses(int statusCode) {
-        HttpClient.ResponseHandler<TokenResponse> responseHandler = authorisationService.responseHandler();
+        HttpClient.ResponseHandler<TokenResponse> responseHandler = authorisationService.responseHandler(TokenResponse.class);
         ResponseHeaders responseHeaders = ResponseHeaders.emptyResponseHeaders();
         InputStream body = new ByteArrayInputStream("body".getBytes());
 


### PR DESCRIPTION
DKB has its own custom model for *POST /psd2-auth/v1/auth/token* request
https://api.dkb.de/store/apis/info?name=PSD2Pre-StepAuthorizationAPI&version=1.0.6&provider=admin#/PSD2-Auth/ValidateCredentials

Missing models were added and mappers created for proper resolving