### PR TITLE
fix unicredit-adapter update payment psu data failing because of invalid links format in response

### DIFF
--- a/adapters/unicredit-adapter/src/main/java/de/adorsys/xs2a/adapter/unicredit/UnicreditMapper.java
+++ b/adapters/unicredit-adapter/src/main/java/de/adorsys/xs2a/adapter/unicredit/UnicreditMapper.java
@@ -4,19 +4,29 @@ import de.adorsys.xs2a.adapter.api.model.*;
 import de.adorsys.xs2a.adapter.unicredit.model.UnicreditOK200TransactionDetails;
 import de.adorsys.xs2a.adapter.unicredit.model.UnicreditTransactionDetails;
 import de.adorsys.xs2a.adapter.unicredit.model.UnicreditTransactionResponse200Json;
+import de.adorsys.xs2a.adapter.unicredit.model.UnicreditUpdatePsuAuthenticationResponse;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
 
 @Mapper
 public interface UnicreditMapper {
     TransactionsResponse200Json toTransactionsResponse200Json(UnicreditTransactionResponse200Json value);
     OK200TransactionDetails toOK200TransactionDetails(UnicreditOK200TransactionDetails value);
     Transactions toTransactions(UnicreditTransactionDetails value);
+    UpdatePsuAuthenticationResponse toUpdatePsuAuthenticationResponse(UnicreditUpdatePsuAuthenticationResponse value);
 
     @Mapping(target = "transactionDetails", expression = "java(toTransactions(value))")
     TransactionDetailsBody toTransactionDetailsBody(UnicreditTransactionDetails value);
 
     default String map(RemittanceInformationStructured value) {
         return value == null ? null : value.getReference();
+    }
+
+    default Map<String, HrefType> map(Collection<Map<String, HrefType>> value) {
+        return value == null ? null : value.stream().findFirst().orElse(new HashMap<>());
     }
 }

--- a/adapters/unicredit-adapter/src/main/java/de/adorsys/xs2a/adapter/unicredit/UnicreditPaymentInitiationService.java
+++ b/adapters/unicredit-adapter/src/main/java/de/adorsys/xs2a/adapter/unicredit/UnicreditPaymentInitiationService.java
@@ -9,6 +9,8 @@ import de.adorsys.xs2a.adapter.api.link.LinksRewriter;
 import de.adorsys.xs2a.adapter.api.model.*;
 import de.adorsys.xs2a.adapter.api.validation.ValidationError;
 import de.adorsys.xs2a.adapter.impl.BasePaymentInitiationService;
+import de.adorsys.xs2a.adapter.unicredit.model.UnicreditUpdatePsuAuthenticationResponse;
+import org.mapstruct.factory.Mappers;
 
 import java.util.List;
 import java.util.Map;
@@ -16,6 +18,7 @@ import java.util.Map;
 public class UnicreditPaymentInitiationService extends BasePaymentInitiationService {
 
     private static final String DEFAULT_COUNTRY_CODE = "DE";
+    private final UnicreditMapper unicreditMapper = Mappers.getMapper(UnicreditMapper.class);
 
     public UnicreditPaymentInitiationService(Aspsp aspsp,
                                              HttpClientFactory httpClientFactory,
@@ -40,6 +43,25 @@ public class UnicreditPaymentInitiationService extends BasePaymentInitiationServ
         }
 
         return super.initiatePayment(paymentService, paymentProduct, requestHeaders, requestParams, requestBody == null ? body : requestBody);
+    }
+
+    @Override
+    public Response<UpdatePsuAuthenticationResponse> updatePaymentPsuData(PaymentService paymentService,
+                                                                          PaymentProduct paymentProduct,
+                                                                          String paymentId,
+                                                                          String authorisationId,
+                                                                          RequestHeaders requestHeaders,
+                                                                          RequestParams requestParams,
+                                                                          UpdatePsuAuthentication updatePsuAuthentication) {
+        return updatePaymentPsuData(paymentService,
+            paymentProduct,
+            paymentId,
+            authorisationId,
+            requestHeaders,
+            requestParams,
+            updatePsuAuthentication,
+            UnicreditUpdatePsuAuthenticationResponse.class,
+            unicreditMapper::toUpdatePsuAuthenticationResponse);
     }
 
     private void addCreditorAddress(Object body) {

--- a/adapters/unicredit-adapter/src/main/java/de/adorsys/xs2a/adapter/unicredit/model/UnicreditUpdatePsuAuthenticationResponse.java
+++ b/adapters/unicredit-adapter/src/main/java/de/adorsys/xs2a/adapter/unicredit/model/UnicreditUpdatePsuAuthenticationResponse.java
@@ -1,0 +1,155 @@
+package de.adorsys.xs2a.adapter.unicredit.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import de.adorsys.xs2a.adapter.api.model.*;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+public class UnicreditUpdatePsuAuthenticationResponse {
+    private Amount transactionFees;
+
+    private Amount currencyConversionFees;
+
+    private Amount estimatedTotalAmount;
+
+    private Amount estimatedInterbankSettlementAmount;
+
+    private AuthenticationObject chosenScaMethod;
+
+    private ChallengeData challengeData;
+
+    private List<AuthenticationObject> scaMethods;
+
+    @JsonProperty("_links")
+    private Collection<Map<String, HrefType>> links;
+
+    private ScaStatus scaStatus;
+
+    private String psuMessage;
+
+    private String authorisationId;
+
+    public Amount getTransactionFees() {
+        return transactionFees;
+    }
+
+    public void setTransactionFees(Amount transactionFees) {
+        this.transactionFees = transactionFees;
+    }
+
+    public Amount getCurrencyConversionFees() {
+        return currencyConversionFees;
+    }
+
+    public void setCurrencyConversionFees(Amount currencyConversionFees) {
+        this.currencyConversionFees = currencyConversionFees;
+    }
+
+    public Amount getEstimatedTotalAmount() {
+        return estimatedTotalAmount;
+    }
+
+    public void setEstimatedTotalAmount(Amount estimatedTotalAmount) {
+        this.estimatedTotalAmount = estimatedTotalAmount;
+    }
+
+    public Amount getEstimatedInterbankSettlementAmount() {
+        return estimatedInterbankSettlementAmount;
+    }
+
+    public void setEstimatedInterbankSettlementAmount(Amount estimatedInterbankSettlementAmount) {
+        this.estimatedInterbankSettlementAmount = estimatedInterbankSettlementAmount;
+    }
+
+    public AuthenticationObject getChosenScaMethod() {
+        return chosenScaMethod;
+    }
+
+    public void setChosenScaMethod(AuthenticationObject chosenScaMethod) {
+        this.chosenScaMethod = chosenScaMethod;
+    }
+
+    public ChallengeData getChallengeData() {
+        return challengeData;
+    }
+
+    public void setChallengeData(ChallengeData challengeData) {
+        this.challengeData = challengeData;
+    }
+
+    public List<AuthenticationObject> getScaMethods() {
+        return scaMethods;
+    }
+
+    public void setScaMethods(List<AuthenticationObject> scaMethods) {
+        this.scaMethods = scaMethods;
+    }
+
+    public Collection<Map<String, HrefType>> getLinks() {
+        return links;
+    }
+
+    public void setLinks(Collection<Map<String, HrefType>> links) {
+        this.links = links;
+    }
+
+    public ScaStatus getScaStatus() {
+        return scaStatus;
+    }
+
+    public void setScaStatus(ScaStatus scaStatus) {
+        this.scaStatus = scaStatus;
+    }
+
+    public String getPsuMessage() {
+        return psuMessage;
+    }
+
+    public void setPsuMessage(String psuMessage) {
+        this.psuMessage = psuMessage;
+    }
+
+    public String getAuthorisationId() {
+        return authorisationId;
+    }
+
+    public void setAuthorisationId(String authorisationId) {
+        this.authorisationId = authorisationId;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        UnicreditUpdatePsuAuthenticationResponse that = (UnicreditUpdatePsuAuthenticationResponse) o;
+        return Objects.equals(transactionFees, that.transactionFees) &&
+            Objects.equals(currencyConversionFees, that.currencyConversionFees) &&
+            Objects.equals(estimatedTotalAmount, that.estimatedTotalAmount) &&
+            Objects.equals(estimatedInterbankSettlementAmount, that.estimatedInterbankSettlementAmount) &&
+            Objects.equals(chosenScaMethod, that.chosenScaMethod) &&
+            Objects.equals(challengeData, that.challengeData) &&
+            Objects.equals(scaMethods, that.scaMethods) &&
+            Objects.equals(links, that.links) &&
+            Objects.equals(scaStatus, that.scaStatus) &&
+            Objects.equals(psuMessage, that.psuMessage) &&
+            Objects.equals(authorisationId, that.authorisationId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(transactionFees,
+            currencyConversionFees,
+            estimatedTotalAmount,
+            estimatedInterbankSettlementAmount,
+            chosenScaMethod,
+            challengeData,
+            scaMethods,
+            links,
+            scaStatus,
+            psuMessage,
+            authorisationId);
+    }
+}

--- a/docs/release_notes/DRAFT_Release_notes_0.1.14.adoc
+++ b/docs/release_notes/DRAFT_Release_notes_0.1.14.adoc
@@ -10,3 +10,4 @@
 == Features:
 
 == Fixes:
+- fixed `unicredit-adapter` update payment psu data failing because of invalid links format in response.


### PR DESCRIPTION
The UniCredit Group returns an invalid response format for updating the psu data for payments:
```json
"_links" : [ {
  "authoriseTransaction" : {
    "href" : "..."
  }
} ]
```
is returned instead of
```json
"_links" : {
  "authoriseTransaction" : {
    "href" : "..."
  }
}
```

The UniCredit support suggested to manage the API response as provided from their system until the fix will be ready for production environment. The final technical solution will require time to be implemented.

This pull request contains a workaround for this problem that needs to be reverted after the UniCredit released the final technical solution.