### PR TITLE
remove subaccount number from PSU-ID for DE/DB and DE/Noris

### DIFF
--- a/adapters/deutsche-bank-adapter/src/main/java/de/adorsys/xs2a/adapter/deutschebank/DeutscheBankServiceProvider.java
+++ b/adapters/deutsche-bank-adapter/src/main/java/de/adorsys/xs2a/adapter/deutschebank/DeutscheBankServiceProvider.java
@@ -26,6 +26,7 @@ import de.adorsys.xs2a.adapter.impl.BaseDownloadService;
 public class DeutscheBankServiceProvider extends AbstractAdapterServiceProvider implements DownloadServiceProvider {
     public static final String SERVICE_GROUP_PLACEHOLDER = "{Service Group}";
     private final PsuIdTypeHeaderInterceptor psuIdTypeHeaderInterceptor = new PsuIdTypeHeaderInterceptor();
+    private final PsuIdHeaderInterceptor psuIdHeaderInterceptor = new PsuIdHeaderInterceptor();
 
     @Override
     public AccountInformationService getAccountInformationService(Aspsp aspsp,
@@ -34,7 +35,7 @@ public class DeutscheBankServiceProvider extends AbstractAdapterServiceProvider 
         aspsp.setUrl(aspsp.getUrl().replace(SERVICE_GROUP_PLACEHOLDER, "ais"));
         return new DeutscheBankAccountInformationService(aspsp,
             httpClientFactory,
-            getInterceptors(aspsp, psuIdTypeHeaderInterceptor),
+            getInterceptors(aspsp, psuIdTypeHeaderInterceptor, psuIdHeaderInterceptor),
             linksRewriter,
             new DeutscheBankPsuPasswordEncryptionService());
     }
@@ -46,7 +47,7 @@ public class DeutscheBankServiceProvider extends AbstractAdapterServiceProvider 
         aspsp.setUrl(aspsp.getUrl().replace(SERVICE_GROUP_PLACEHOLDER, "pis"));
         return new DeutscheBankPaymentInitiationService(aspsp,
             httpClientFactory,
-            getInterceptors(aspsp, psuIdTypeHeaderInterceptor),
+            getInterceptors(aspsp, psuIdTypeHeaderInterceptor, psuIdHeaderInterceptor),
             linksRewriter);
     }
 

--- a/adapters/deutsche-bank-adapter/src/main/java/de/adorsys/xs2a/adapter/deutschebank/PsuIdHeaderInterceptor.java
+++ b/adapters/deutsche-bank-adapter/src/main/java/de/adorsys/xs2a/adapter/deutschebank/PsuIdHeaderInterceptor.java
@@ -1,0 +1,39 @@
+package de.adorsys.xs2a.adapter.deutschebank;
+
+import de.adorsys.xs2a.adapter.api.RequestHeaders;
+import de.adorsys.xs2a.adapter.api.http.Interceptor;
+import de.adorsys.xs2a.adapter.api.http.Request;
+
+import java.net.URI;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+/**
+ * For DE/DB and DE/Noris the subaccount number will be removed from the PSU-ID if present.
+ */
+public class PsuIdHeaderInterceptor implements Interceptor {
+    @Override
+    public Request.Builder preHandle(Request.Builder builder) {
+        String psuId = builder.headers().get(RequestHeaders.PSU_ID);
+        if (psuId != null) {
+            trimPsuId(builder, psuId);
+        }
+        return builder;
+    }
+
+    private void trimPsuId(Request.Builder builder, String psuId) {
+        URI uri = URI.create(builder.uri());
+        Path path = Paths.get(uri.getPath());
+        if (path.getNameCount() < 3) {
+            return;
+        }
+        String countryCode = path.getName(1).toString();
+        if ("DE".equals(countryCode)) {
+            String businessEntity = path.getName(2).toString();
+            if (("DB".equals(businessEntity) || "Noris".equals(businessEntity))
+                && psuId.length() == 12) {
+                builder.header(RequestHeaders.PSU_ID, psuId.substring(0, 10));
+            }
+        }
+    }
+}

--- a/adapters/deutsche-bank-adapter/src/test/java/de/adorsys/xs2a/adapter/deutschebank/PsuIdHeaderInterceptorTest.java
+++ b/adapters/deutsche-bank-adapter/src/test/java/de/adorsys/xs2a/adapter/deutschebank/PsuIdHeaderInterceptorTest.java
@@ -1,0 +1,84 @@
+package de.adorsys.xs2a.adapter.deutschebank;
+
+import de.adorsys.xs2a.adapter.api.RequestHeaders;
+import de.adorsys.xs2a.adapter.impl.http.RequestBuilderImpl;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class PsuIdHeaderInterceptorTest {
+    private PsuIdHeaderInterceptor interceptor;
+    private RequestBuilderImpl builder;
+
+    @BeforeEach
+    public void setUp() {
+        interceptor = new PsuIdHeaderInterceptor();
+        builder = new RequestBuilderImpl(null, null, null);
+    }
+
+    @Test
+    void trimsPsuIdForDeutscheBankInGermanyWhenPsuIdLengthIsTwelve() {
+        builder.uri("https://xs2a.db.com/ais/DE/DB");
+        builder.header(RequestHeaders.PSU_ID, "123456789012");
+        interceptor.preHandle(builder);
+        assertEquals("1234567890", builder.headers().get(RequestHeaders.PSU_ID));
+    }
+
+    @Test
+    void trimsPsuIdForNorisbankInGermanyWhenPsuIdLengthIsTwelve() {
+        builder.uri("https://xs2a.db.com/ais/DE/Noris");
+        builder.header(RequestHeaders.PSU_ID, "123456789012");
+        interceptor.preHandle(builder);
+        assertEquals("1234567890", builder.headers().get(RequestHeaders.PSU_ID));
+    }
+
+    @Test
+    void doesNothingForPostbankInGermanyWhenPsuIdLengthIsTwelve() {
+        builder.uri("https://xs2a.db.com/ais/DE/Postbank");
+        builder.header(RequestHeaders.PSU_ID, "123456789012");
+        interceptor.preHandle(builder);
+        assertEquals("123456789012", builder.headers().get(RequestHeaders.PSU_ID));
+    }
+
+    @Test
+    void doesNothingForDeutscheBankInGermanyWhenPsuIdLengthIsTen() {
+        builder.uri("https://xs2a.db.com/ais/DE/DB");
+        builder.header(RequestHeaders.PSU_ID, "1234567890");
+        interceptor.preHandle(builder);
+        assertEquals("1234567890", builder.headers().get(RequestHeaders.PSU_ID));
+    }
+
+    @Test
+    void doesNothingForNorisbankInGermanyWhenPsuIdLengthIsTen() {
+        builder.uri("https://xs2a.db.com/ais/DE/Noris");
+        builder.header(RequestHeaders.PSU_ID, "1234567890");
+        interceptor.preHandle(builder);
+        assertEquals("1234567890", builder.headers().get(RequestHeaders.PSU_ID));
+    }
+
+    @Test
+    void doesNothingForNorisbankInGermanyWhenPsuIdLengthIsEleven() {
+        builder.uri("https://xs2a.db.com/ais/DE/Noris");
+        builder.header(RequestHeaders.PSU_ID, "12345678901");
+        interceptor.preHandle(builder);
+        assertEquals("12345678901", builder.headers().get(RequestHeaders.PSU_ID));
+    }
+
+    @Test
+    void doesNothingWhenPsuIdIsNotSet() {
+        builder.uri("https://xs2a.db.com/ais/DE/DB");
+        interceptor.preHandle(builder);
+        assertNull(builder.headers().get(RequestHeaders.PSU_ID));
+    }
+
+    @Test
+    void hasBoundsChecksInCasePathIsTooShort() {
+        builder.uri("https://xs2a.db.com/");
+        try {
+            interceptor.preHandle(builder);
+        } catch (IndexOutOfBoundsException e) {
+            fail();
+        }
+    }
+}

--- a/docs/release_notes/DRAFT_Release_notes_0.1.14.adoc
+++ b/docs/release_notes/DRAFT_Release_notes_0.1.14.adoc
@@ -13,6 +13,7 @@
 - added `Glossary` to the Adapter arc42 document.
 
 == Features:
+- `deutsche-bank-adapter` removes subaccount number from PSU-ID for DE/DB and DE/Noris if present.
 
 == Fixes:
 - fixed `unicredit-adapter` update payment psu data failing because of invalid links format in response.


### PR DESCRIPTION
The user ID of DE/DB and DE/Noris is composed as follows:
- 3 digit branch number
- 7 digit account number
- 2 digit subaccount number

The subaccount number is **not** part of the PSU-ID for XS2A.

I implemented an interceptor that removes the subaccount number for DE/DB and DE/Noris from the PSU-ID if necessary.

For more information, see Technical Documentation Chapter 9.3.2.