### PR TITLE
Add Aareal Bank

### DIFF
--- a/adapters/crealogix-adapter/README.md
+++ b/adapters/crealogix-adapter/README.md
@@ -4,6 +4,7 @@ This adapter covers banks which use a PSD2 API solution provided by [CREALOGIX G
 
 Connected CREALOGIX banks:
 - DKB
+- Aareal Bank
 
 ### Configuration
 
@@ -20,6 +21,25 @@ This call will create a TPP record within ASPSP database. For example with DKB, 
 
 ```
 curl --location POST 'https://api.dkb.de/psd2/v1/consents' \
+--cert $CERT_PATH \
+--key $PR_KEY_PATH \
+--header 'Content-Type: application/json' \
+--data-raw '{
+    "access": {
+        "allPsd2": "allAccounts"
+    },
+    "combinedServiceIndicator": "false",
+    "recurringIndicator": "true",
+    "validUntil": "2023-05-18",
+    "frequencyPerDay": "4"
+}'
+
+```
+
+For Aareal Bank:
+
+```
+curl --location POST 'https://tpp.aareal-bank.com/psd2/1.3.6/v1/consents' \
 --cert $CERT_PATH \
 --key $PR_KEY_PATH \
 --header 'Content-Type: application/json' \

--- a/docs/developer_guide.md
+++ b/docs/developer_guide.md
@@ -39,7 +39,7 @@ if you need a production data please contact our [sales team](mailto:rene.pongra
 
 In order to communicate with some banks additional steps are compulsory.
 
-#### DKB
+#### DKB and Aareal Bank
 
 The registration is needed. However, the process is merely simple - a user will want to call any DKB PSD2 endpoint 
 with production certificates, e.g.
@@ -62,7 +62,7 @@ curl --location POST 'https://api.dkb.de/psd2/v1/consents' \
 
 It will return 401 UNAUTHORIZED for a successful registration.
 
-Details about DKB [here](../adapters/crealogix-adapter/README.md)
+Details about DKB and Aareal Bank [here](../adapters/crealogix-adapter/README.md)
 
 #### Santander
 

--- a/docs/release_notes/DRAFT_Release_notes_0.1.15.adoc
+++ b/docs/release_notes/DRAFT_Release_notes_0.1.15.adoc
@@ -2,6 +2,9 @@
 
 .Added banks
 |===
+|Bank Name|Approach|AIS, PIS
+
+|Aareal Bank (Crealogix Solution)|embedded|AIS, PIS
 |===
 
 == Notices:

--- a/xs2a-adapter-aspsp-registry/src/main/resources/aspsp-adapter-config.csv
+++ b/xs2a-adapter-aspsp-registry/src/main/resources/aspsp-adapter-config.csv
@@ -1284,7 +1284,8 @@ ee08e556-8050-44d0-bf1e-af01e189ff5b,VOLKSBANK NIENBURG,GENODEF1NIN,https://xs2a
 ee718361-b893-40d8-ab54-1ae9517b43df,VOLKSBANK NIENBURG,GENODEF1NIN,https://xs2a-test.fiduciagad.de/xs2a/bg13,fiducia-adapter,25690010
 c66fff43-2374-4327-9431-073528f9dd0e,Landbank Horlofftal,GENODE51REW,https://xs2a-test.fiduciagad.de/xs2a/bg13,fiducia-adapter,51861616
 29c4d3da-78eb-4458-8195-03873b9bb66a,Volksbank Filder,GENODES1NHB,https://xs2a-test.fiduciagad.de/xs2a/bg13,fiducia-adapter,61161696
-335562a2-26e2-4105-b31e-08de285234e0,DKB,BYLADEM1001,https://preview.wso2-clx.crealogix-online.com/psd2sandbox,dkb-adapter,,https://preview.wso2-clx.crealogix-online.com
+335562a2-26e2-4105-b31e-08de285234e0,DKB,BYLADEM1001,https://api.dkb.de/psd2sandbox/1.3.6,dkb-adapter,12030000,https://api.dkb.de/psd2sandbox
+7ffc3d6c-d02c-49fe-8686-ce68efef6165,Aareal Bank,AARBDE5WXXX,https://api.dkb.de/psd2sandbox/1.3.6,dkb-adapter,51010400,https://api.dkb.de/psd2sandbox
 369d86be-fb3f-4a2a-a7d9-481f9ae38abb,Volksbank Ruhr Mitte eG,GENODEM1HWE,https://xs2a-test.fiduciagad.de/xs2a/bg13,fiducia-adapter,
 d21b72e6-f213-4858-bd97-44e22af0f878,Volksbank im Ostmünsterland eG,GENODEM1HWI,https://xs2a-test.fiduciagad.de/xs2a/bg13,fiducia-adapter,47861518
 07b508ff-04ef-465b-9883-e7209a867c84,Ostsächsische Sparkasse Dresden,OSDDDE81HDN,https://xs2a-sandbox.f-i-apim.de:8444/fixs2a-env/xs2a-api/12345678,sparkasse-adapter,85050300


### PR DESCRIPTION
Implying from the bank documentation, the existing `dkb-adapter` should perfectly work for all Aareal banks, thus only a record with Aareal information is needed and it was added to the CSV with `dkb-adapter` ID.