### PR TITLE
Fix sparkasse wiremock stubs

### DIFF
--- a/adapters/sparkasse-adapter/src/main/resources/sparkasse-adapter/mappings/ais-create-consent.json
+++ b/adapters/sparkasse-adapter/src/main/resources/sparkasse-adapter/mappings/ais-create-consent.json
@@ -2,7 +2,7 @@
   "id" : "2d8c8b3e-a819-4ae9-9919-ef0fd32c2e77",
   "name" : "v1_consents",
   "request" : {
-    "url" : "/v1/consents",
+    "urlPattern" : ".*/v1/consents",
     "method" : "POST",
     "headers" : {
       "X-Request-ID" : {

--- a/adapters/sparkasse-adapter/src/main/resources/sparkasse-adapter/mappings/ais-delete-consent.json
+++ b/adapters/sparkasse-adapter/src/main/resources/sparkasse-adapter/mappings/ais-delete-consent.json
@@ -2,7 +2,7 @@
   "id" : "ed9b1fb4-bc6c-4fc6-b6bb-6c0cb3a264bf",
   "name" : "v1_consents_e3d6fd32-8e41-498b-a20a-c643215e420c",
   "request" : {
-    "urlPattern" : "/v1/consents/.+",
+    "urlPattern" : ".*/v1/consents/.+",
     "method" : "DELETE",
     "headers" : {
       "X-Request-ID" : {

--- a/adapters/sparkasse-adapter/src/main/resources/sparkasse-adapter/mappings/ais-get-accounts.json
+++ b/adapters/sparkasse-adapter/src/main/resources/sparkasse-adapter/mappings/ais-get-accounts.json
@@ -2,7 +2,7 @@
   "id" : "c8c2b316-9eda-4334-9a4a-199a1f4ef844",
   "name" : "v1_accounts",
   "request" : {
-    "url" : "/v1/accounts?withBalance=false",
+    "urlPattern" : ".*/v1/accounts\\?withBalance=false",
     "method" : "GET",
     "headers" : {
       "X-Request-ID" : {

--- a/adapters/sparkasse-adapter/src/main/resources/sparkasse-adapter/mappings/ais-get-consent-status.json
+++ b/adapters/sparkasse-adapter/src/main/resources/sparkasse-adapter/mappings/ais-get-consent-status.json
@@ -2,7 +2,7 @@
   "id" : "652c47ec-99d1-4b70-8cba-0a3987ddd0ce",
   "name" : "v1_consents_e3d6fd32-8e41-498b-a20a-c643215e420c_status",
   "request" : {
-    "urlPattern" : "/v1/consents/.+/status",
+    "urlPattern" : ".*/v1/consents/.+/status",
     "method" : "GET",
     "headers" : {
       "X-Request-ID" : {

--- a/adapters/sparkasse-adapter/src/main/resources/sparkasse-adapter/mappings/ais-get-sca-status.json
+++ b/adapters/sparkasse-adapter/src/main/resources/sparkasse-adapter/mappings/ais-get-sca-status.json
@@ -2,7 +2,7 @@
   "id" : "14b2e727-ea44-4d0d-aaff-db5812d0140c",
   "name" : "v1_consents_e3d6fd32-8e41-498b-a20a-c643215e420c_authorisations_a7129418-87e2-43c3-ba57-38aa2e23093b",
   "request" : {
-    "urlPattern" : "/v1/consents/.+/authorisations/.+",
+    "urlPattern" : ".*/v1/consents/.+/authorisations/.+",
     "method" : "GET",
     "headers" : {
       "X-Request-ID" : {

--- a/adapters/sparkasse-adapter/src/main/resources/sparkasse-adapter/mappings/ais-get-transactions.json
+++ b/adapters/sparkasse-adapter/src/main/resources/sparkasse-adapter/mappings/ais-get-transactions.json
@@ -2,7 +2,7 @@
   "id" : "223e646a-6b1f-4023-b89a-e22d36bf8687",
   "name" : "v1_accounts_3217d050-f5b5-4318-a799-413bce784ef6_transactions",
   "request" : {
-    "urlPattern" : "/v1/accounts/.+/transactions\\?dateFrom=.+&dateTo=.+&bookingStatus=booked&withBalance=true",
+    "urlPattern" : ".*/v1/accounts/.+/transactions\\?dateFrom=.+&dateTo=.+&bookingStatus=booked&withBalance=true",
     "method" : "GET",
     "headers" : {
       "X-Request-ID" : {

--- a/adapters/sparkasse-adapter/src/main/resources/sparkasse-adapter/mappings/ais-select-sca-method.json
+++ b/adapters/sparkasse-adapter/src/main/resources/sparkasse-adapter/mappings/ais-select-sca-method.json
@@ -22,14 +22,14 @@
       }
     },
     "bodyPatterns" : [ {
-      "equalToJson" : "{\"authenticationMethodId\":\"MANUAL\"}",
+      "equalToJson" : "{\"authenticationMethodId\":\"OPTICAL\"}",
       "ignoreArrayOrder" : true,
       "ignoreExtraElements" : true
     } ]
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"scaStatus\":\"scaMethodSelected\",\"chosenScaMethod\":{\"authenticationType\":\"CHIP_OTP\",\"authenticationMethodId\":\"MANUAL\",\"authenticationVersion\":\"HHD1.3.2\",\"name\":\"chipTAN MANUAL | Kartennummer: ******9876\",\"explanation\":\"Erfassung der Auftragsdaten über die Tasten Ihres TAN-Generator.\"},\"challengeData\":{\"otpMaxLength\":6,\"otpFormat\":\"integer\",\"additionalInformation\":\"Sie haben eine 'Einzelüberweisung' erfasst: Überprüfen Sie die Richtigkeit der 'letzten 10 Zeichen der IBAN des Empfängers' und bestätigen Sie diese mit der Taste 'OK'. Überprüfen Sie die Richtigkeit des 'Betrags' und bestätigen Sie diesen mit der Taste 'OK'.\"},\"_links\":{\"authoriseTransaction\":{\"href\":\"https://xs2a-sandbox.f-i-apim.de:8444/fixs2a-env/xs2a-api/12345678/v1/consents/e3d6fd32-8e41-498b-a20a-c643215e420c/authorisations/a7129418-87e2-43c3-ba57-38aa2e23093b\"},\"scaStatus\":{\"href\":\"https://xs2a-sandbox.f-i-apim.de:8444/fixs2a-env/xs2a-api/12345678/v1/consents/e3d6fd32-8e41-498b-a20a-c643215e420c/authorisations/a7129418-87e2-43c3-ba57-38aa2e23093b\"}},\"psuMessage\":\"Bitte geben Sie die TAN ein.\"}",
+    "body" : "{\"scaStatus\":\"scaMethodSelected\",\"chosenScaMethod\":{\"authenticationType\":\"CHIP_OTP\",\"authenticationMethodId\":\"OPTICAL\",\"authenticationVersion\":\"HHD1.3.2\",\"name\":\"chipTAN MANUAL | Kartennummer: ******9876\",\"explanation\":\"Erfassung der Auftragsdaten über die Tasten Ihres TAN-Generator.\"},\"challengeData\":{\"otpMaxLength\":6,\"otpFormat\":\"integer\",\"additionalInformation\":\"Sie haben eine 'Einzelüberweisung' erfasst: Überprüfen Sie die Richtigkeit der 'letzten 10 Zeichen der IBAN des Empfängers' und bestätigen Sie diese mit der Taste 'OK'. Überprüfen Sie die Richtigkeit des 'Betrags' und bestätigen Sie diesen mit der Taste 'OK'.\"},\"_links\":{\"authoriseTransaction\":{\"href\":\"https://xs2a-sandbox.f-i-apim.de:8444/fixs2a-env/xs2a-api/12345678/v1/consents/e3d6fd32-8e41-498b-a20a-c643215e420c/authorisations/a7129418-87e2-43c3-ba57-38aa2e23093b\"},\"scaStatus\":{\"href\":\"https://xs2a-sandbox.f-i-apim.de:8444/fixs2a-env/xs2a-api/12345678/v1/consents/e3d6fd32-8e41-498b-a20a-c643215e420c/authorisations/a7129418-87e2-43c3-ba57-38aa2e23093b\"}},\"psuMessage\":\"Bitte geben Sie die TAN ein.\"}",
     "headers" : {
       "Date" : "Thu, 06 Aug 2020 09:03:46 GMT",
       "Server" : "Apache",

--- a/adapters/sparkasse-adapter/src/main/resources/sparkasse-adapter/mappings/ais-select-sca-method.json
+++ b/adapters/sparkasse-adapter/src/main/resources/sparkasse-adapter/mappings/ais-select-sca-method.json
@@ -2,7 +2,7 @@
   "id" : "7f5448ee-3988-4742-bae6-5ca325b72b0d",
   "name" : "v1_consents_e3d6fd32-8e41-498b-a20a-c643215e420c_authorisations_a7129418-87e2-43c3-ba57-38aa2e23093b",
   "request" : {
-    "urlPattern" : "/v1/consents/.+/authorisations/.+",
+    "urlPattern" : ".*/v1/consents/.+/authorisations/.+",
     "method" : "PUT",
     "headers" : {
       "X-Request-ID" : {

--- a/adapters/sparkasse-adapter/src/main/resources/sparkasse-adapter/mappings/ais-send-otp.json
+++ b/adapters/sparkasse-adapter/src/main/resources/sparkasse-adapter/mappings/ais-send-otp.json
@@ -2,7 +2,7 @@
   "id" : "f78929d3-6c23-4b4e-b28d-34941546b4b3",
   "name" : "v1_consents_e3d6fd32-8e41-498b-a20a-c643215e420c_authorisations_a7129418-87e2-43c3-ba57-38aa2e23093b",
   "request" : {
-    "urlPattern" : "/v1/consents/.+/authorisations/.+",
+    "urlPattern" : ".*/v1/consents/.+/authorisations/.+",
     "method" : "PUT",
     "headers" : {
       "X-Request-ID" : {

--- a/adapters/sparkasse-adapter/src/main/resources/sparkasse-adapter/mappings/ais-start-psu-authentication.json
+++ b/adapters/sparkasse-adapter/src/main/resources/sparkasse-adapter/mappings/ais-start-psu-authentication.json
@@ -2,7 +2,7 @@
   "id" : "322e7f81-9535-45e7-8a20-b0f37547a99a",
   "name" : "v1_consents_e3d6fd32-8e41-498b-a20a-c643215e420c_authorisations",
   "request" : {
-    "urlPattern" : "/v1/consents/.+/authorisations",
+    "urlPattern" : ".*/v1/consents/.+/authorisations",
     "method" : "POST",
     "headers" : {
       "X-Request-ID" : {

--- a/adapters/sparkasse-adapter/src/main/resources/sparkasse-adapter/mappings/pis-payments-pain001-sct-get-payment-status.json
+++ b/adapters/sparkasse-adapter/src/main/resources/sparkasse-adapter/mappings/pis-payments-pain001-sct-get-payment-status.json
@@ -2,7 +2,7 @@
   "id" : "012faa6c-df35-4d2f-a3bb-225704860dc7",
   "name" : "v1_payments_pain001-sepa-credit-transfers_850987d5-eb54-4053-84c1-945485147e3b_status",
   "request" : {
-    "urlPattern" : "/v1/payments/pain.001-sepa-credit-transfers/.+/status",
+    "urlPattern" : ".*/v1/payments/pain.001-sepa-credit-transfers/.+/status",
     "method" : "GET",
     "headers" : {
       "X-Request-ID" : {

--- a/adapters/sparkasse-adapter/src/main/resources/sparkasse-adapter/mappings/pis-payments-pain001-sct-get-sca-status.json
+++ b/adapters/sparkasse-adapter/src/main/resources/sparkasse-adapter/mappings/pis-payments-pain001-sct-get-sca-status.json
@@ -2,7 +2,7 @@
   "id" : "70d2f382-4c25-4050-b288-8cce6ba581f6",
   "name" : "v1_payments_pain001-sepa-credit-transfers_850987d5-eb54-4053-84c1-945485147e3b_authorisations_cafd117d-2969-48be-b003-acd835bb02e6",
   "request" : {
-    "urlPattern" : "/v1/payments/pain.001-sepa-credit-transfers/.+/authorisations/.+",
+    "urlPattern" : ".*/v1/payments/pain.001-sepa-credit-transfers/.+/authorisations/.+",
     "method" : "GET",
     "headers" : {
       "X-Request-ID" : {

--- a/adapters/sparkasse-adapter/src/main/resources/sparkasse-adapter/mappings/pis-payments-pain001-sct-initiate-payment.json
+++ b/adapters/sparkasse-adapter/src/main/resources/sparkasse-adapter/mappings/pis-payments-pain001-sct-initiate-payment.json
@@ -2,7 +2,7 @@
   "id" : "55e2ba0e-f856-4f38-85e0-4e6824a5ad83",
   "name" : "v1_payments_pain001-sepa-credit-transfers",
   "request" : {
-    "url" : "/v1/payments/pain.001-sepa-credit-transfers",
+    "urlPattern" : ".*/v1/payments/pain.001-sepa-credit-transfers",
     "method" : "POST",
     "headers" : {
       "X-Request-ID" : {

--- a/adapters/sparkasse-adapter/src/main/resources/sparkasse-adapter/mappings/pis-payments-pain001-sct-select-sca-method.json
+++ b/adapters/sparkasse-adapter/src/main/resources/sparkasse-adapter/mappings/pis-payments-pain001-sct-select-sca-method.json
@@ -2,7 +2,7 @@
   "id" : "8f4a2540-ea37-464c-9b24-b30dae495300",
   "name" : "v1_payments_pain001-sepa-credit-transfers_850987d5-eb54-4053-84c1-945485147e3b_authorisations_cafd117d-2969-48be-b003-acd835bb02e6",
   "request" : {
-    "urlPattern" : "/v1/payments/pain.001-sepa-credit-transfers/.+/authorisations/.+",
+    "urlPattern" : ".*/v1/payments/pain.001-sepa-credit-transfers/.+/authorisations/.+",
     "method" : "PUT",
     "headers" : {
       "X-Request-ID" : {

--- a/adapters/sparkasse-adapter/src/main/resources/sparkasse-adapter/mappings/pis-payments-pain001-sct-send-otp.json
+++ b/adapters/sparkasse-adapter/src/main/resources/sparkasse-adapter/mappings/pis-payments-pain001-sct-send-otp.json
@@ -2,7 +2,7 @@
   "id" : "9670ecdb-e205-4615-956a-26b40a0dbe91",
   "name" : "v1_payments_pain001-sepa-credit-transfers_850987d5-eb54-4053-84c1-945485147e3b_authorisations_cafd117d-2969-48be-b003-acd835bb02e6",
   "request" : {
-    "urlPattern" : "/v1/payments/pain.001-sepa-credit-transfers/.+/authorisations/.+",
+    "urlPattern" : ".*/v1/payments/pain.001-sepa-credit-transfers/.+/authorisations/.+",
     "method" : "PUT",
     "headers" : {
       "X-Request-ID" : {

--- a/adapters/sparkasse-adapter/src/main/resources/sparkasse-adapter/mappings/pis-payments-pain001-sct-start-psu-authentication.json
+++ b/adapters/sparkasse-adapter/src/main/resources/sparkasse-adapter/mappings/pis-payments-pain001-sct-start-psu-authentication.json
@@ -2,7 +2,7 @@
   "id" : "c4d4ee12-d29c-491b-b170-ceecaa56870e",
   "name" : "v1_payments_pain001-sepa-credit-transfers_850987d5-eb54-4053-84c1-945485147e3b_authorisations",
   "request" : {
-    "urlPattern" : "/v1/payments/pain.001-sepa-credit-transfers/.+/authorisations",
+    "urlPattern" : ".*/v1/payments/pain.001-sepa-credit-transfers/.+/authorisations",
     "method" : "POST",
     "headers" : {
       "X-Request-ID" : {

--- a/adapters/sparkasse-adapter/src/main/resources/sparkasse-adapter/mappings/pis-payments-sct-get-payment-status.json
+++ b/adapters/sparkasse-adapter/src/main/resources/sparkasse-adapter/mappings/pis-payments-sct-get-payment-status.json
@@ -2,7 +2,7 @@
   "id" : "ac22145d-3e6f-4144-bdd1-e2b3e2eb6199",
   "name" : "v1_payments_sepa-credit-transfers_5f6e3778-2b5c-460c-90f9-c86b0f5c5d57_status",
   "request" : {
-    "urlPattern" : "/v1/payments/sepa-credit-transfers/.+/status",
+    "urlPattern" : ".*/v1/payments/sepa-credit-transfers/.+/status",
     "method" : "GET",
     "headers" : {
       "X-Request-ID" : {

--- a/adapters/sparkasse-adapter/src/main/resources/sparkasse-adapter/mappings/pis-payments-sct-get-sca-status.json
+++ b/adapters/sparkasse-adapter/src/main/resources/sparkasse-adapter/mappings/pis-payments-sct-get-sca-status.json
@@ -2,7 +2,7 @@
   "id" : "2efa891e-90b1-427a-ae1c-1565021b0056",
   "name" : "v1_payments_sepa-credit-transfers_5f6e3778-2b5c-460c-90f9-c86b0f5c5d57_authorisations_c9ef5300-0091-47c6-9df9-2190313e8f03",
   "request" : {
-    "urlPattern" : "/v1/payments/sepa-credit-transfers/.+/authorisations/.+",
+    "urlPattern" : ".*/v1/payments/sepa-credit-transfers/.+/authorisations/.+",
     "method" : "GET",
     "headers" : {
       "X-Request-ID" : {

--- a/adapters/sparkasse-adapter/src/main/resources/sparkasse-adapter/mappings/pis-payments-sct-initiate-payment.json
+++ b/adapters/sparkasse-adapter/src/main/resources/sparkasse-adapter/mappings/pis-payments-sct-initiate-payment.json
@@ -2,7 +2,7 @@
   "id" : "57876e20-85a8-4430-9a25-82dbbe77056b",
   "name" : "v1_payments_sepa-credit-transfers",
   "request" : {
-    "url" : "/v1/payments/sepa-credit-transfers",
+    "urlPattern" : ".*/v1/payments/sepa-credit-transfers",
     "method" : "POST",
     "headers" : {
       "X-Request-ID" : {

--- a/adapters/sparkasse-adapter/src/main/resources/sparkasse-adapter/mappings/pis-payments-sct-select-sca-method.json
+++ b/adapters/sparkasse-adapter/src/main/resources/sparkasse-adapter/mappings/pis-payments-sct-select-sca-method.json
@@ -22,14 +22,14 @@
       }
     },
     "bodyPatterns" : [ {
-      "equalToJson" : "{\"authenticationMethodId\":\"MANUAL\"}",
+      "equalToJson" : "{\"authenticationMethodId\":\"OPTICAL\"}",
       "ignoreArrayOrder" : true,
       "ignoreExtraElements" : true
     } ]
   },
   "response" : {
     "status" : 200,
-    "body" : "{\"scaStatus\":\"scaMethodSelected\",\"chosenScaMethod\":{\"authenticationType\":\"CHIP_OTP\",\"authenticationMethodId\":\"MANUAL\",\"authenticationVersion\":\"HHD1.3.2\",\"name\":\"chipTAN MANUAL | Kartennummer: ******9876\",\"explanation\":\"Erfassung der Auftragsdaten über die Tasten Ihres TAN-Generator.\"},\"challengeData\":{\"otpMaxLength\":6,\"otpFormat\":\"integer\",\"additionalInformation\":\"Sie haben eine 'Einzelüberweisung' erfasst: Überprüfen Sie die Richtigkeit der 'letzten 10 Zeichen der IBAN des Empfängers' und bestätigen Sie diese mit der Taste 'OK'. Überprüfen Sie die Richtigkeit des 'Betrags' und bestätigen Sie diesen mit der Taste 'OK'.\"},\"_links\":{\"scaStatus\":{\"href\":\"https://xs2a-sandbox.f-i-apim.de:8444/fixs2a-env/xs2a-api/12345678/v1/payments/sepa-credit-transfers/5f6e3778-2b5c-460c-90f9-c86b0f5c5d57/authorisations/c9ef5300-0091-47c6-9df9-2190313e8f03\"},\"authoriseTransaction\":{\"href\":\"https://xs2a-sandbox.f-i-apim.de:8444/fixs2a-env/xs2a-api/12345678/v1/payments/sepa-credit-transfers/5f6e3778-2b5c-460c-90f9-c86b0f5c5d57/authorisations/c9ef5300-0091-47c6-9df9-2190313e8f03\"}},\"psuMessage\":\"Bitte geben Sie die TAN ein.\"}",
+    "body" : "{\"scaStatus\":\"scaMethodSelected\",\"chosenScaMethod\":{\"authenticationType\":\"CHIP_OTP\",\"authenticationMethodId\":\"OPTICAL\",\"authenticationVersion\":\"HHD1.3.2\",\"name\":\"chipTAN MANUAL | Kartennummer: ******9876\",\"explanation\":\"Erfassung der Auftragsdaten über die Tasten Ihres TAN-Generator.\"},\"challengeData\":{\"otpMaxLength\":6,\"otpFormat\":\"integer\",\"additionalInformation\":\"Sie haben eine 'Einzelüberweisung' erfasst: Überprüfen Sie die Richtigkeit der 'letzten 10 Zeichen der IBAN des Empfängers' und bestätigen Sie diese mit der Taste 'OK'. Überprüfen Sie die Richtigkeit des 'Betrags' und bestätigen Sie diesen mit der Taste 'OK'.\"},\"_links\":{\"scaStatus\":{\"href\":\"https://xs2a-sandbox.f-i-apim.de:8444/fixs2a-env/xs2a-api/12345678/v1/payments/sepa-credit-transfers/5f6e3778-2b5c-460c-90f9-c86b0f5c5d57/authorisations/c9ef5300-0091-47c6-9df9-2190313e8f03\"},\"authoriseTransaction\":{\"href\":\"https://xs2a-sandbox.f-i-apim.de:8444/fixs2a-env/xs2a-api/12345678/v1/payments/sepa-credit-transfers/5f6e3778-2b5c-460c-90f9-c86b0f5c5d57/authorisations/c9ef5300-0091-47c6-9df9-2190313e8f03\"}},\"psuMessage\":\"Bitte geben Sie die TAN ein.\"}",
     "headers" : {
       "Date" : "Tue, 11 Aug 2020 07:47:39 GMT",
       "Server" : "Apache",

--- a/adapters/sparkasse-adapter/src/main/resources/sparkasse-adapter/mappings/pis-payments-sct-select-sca-method.json
+++ b/adapters/sparkasse-adapter/src/main/resources/sparkasse-adapter/mappings/pis-payments-sct-select-sca-method.json
@@ -2,7 +2,7 @@
   "id" : "da43e19d-657f-4462-925b-c2f4d75d35a1",
   "name" : "v1_payments_sepa-credit-transfers_5f6e3778-2b5c-460c-90f9-c86b0f5c5d57_authorisations_c9ef5300-0091-47c6-9df9-2190313e8f03",
   "request" : {
-    "urlPattern" : "/v1/payments/sepa-credit-transfers/.+/authorisations/.+",
+    "urlPattern" : ".*/v1/payments/sepa-credit-transfers/.+/authorisations/.+",
     "method" : "PUT",
     "headers" : {
       "X-Request-ID" : {

--- a/adapters/sparkasse-adapter/src/main/resources/sparkasse-adapter/mappings/pis-payments-sct-send-otp.json
+++ b/adapters/sparkasse-adapter/src/main/resources/sparkasse-adapter/mappings/pis-payments-sct-send-otp.json
@@ -2,7 +2,7 @@
   "id" : "108ae84f-ed3f-4975-beda-bb6f123a08fc",
   "name" : "v1_payments_sepa-credit-transfers_5f6e3778-2b5c-460c-90f9-c86b0f5c5d57_authorisations_c9ef5300-0091-47c6-9df9-2190313e8f03",
   "request" : {
-    "urlPattern" : "/v1/payments/sepa-credit-transfers/.+/authorisations/.+",
+    "urlPattern" : ".*/v1/payments/sepa-credit-transfers/.+/authorisations/.+",
     "method" : "PUT",
     "headers" : {
       "X-Request-ID" : {

--- a/adapters/sparkasse-adapter/src/main/resources/sparkasse-adapter/mappings/pis-payments-sct-start-psu-authentication.json
+++ b/adapters/sparkasse-adapter/src/main/resources/sparkasse-adapter/mappings/pis-payments-sct-start-psu-authentication.json
@@ -2,7 +2,7 @@
   "id" : "8241860a-dbd8-4a5d-9379-6c10150897b9",
   "name" : "v1_payments_sepa-credit-transfers_5f6e3778-2b5c-460c-90f9-c86b0f5c5d57_authorisations",
   "request" : {
-    "urlPattern" : "/v1/payments/sepa-credit-transfers/.+/authorisations",
+    "urlPattern" : ".*/v1/payments/sepa-credit-transfers/.+/authorisations",
     "method" : "POST",
     "headers" : {
       "X-Request-ID" : {

--- a/adapters/sparkasse-adapter/src/test/resources/ais/select-sca-method.json
+++ b/adapters/sparkasse-adapter/src/test/resources/ais/select-sca-method.json
@@ -8,7 +8,7 @@
       "Content-Type": "application/json; charset=UTF-8"
     },
     "body": {
-      "authenticationMethodId": "MANUAL"
+      "authenticationMethodId": "OPTICAL"
     }
   },
   "response": {
@@ -16,7 +16,7 @@
       "scaStatus": "scaMethodSelected",
       "chosenScaMethod": {
         "authenticationType": "CHIP_OTP",
-        "authenticationMethodId": "MANUAL",
+        "authenticationMethodId": "OPTICAL",
         "authenticationVersion": "HHD1.3.2",
         "name": "chipTAN MANUAL | Kartennummer: ******9876",
         "explanation": "Erfassung der Auftragsdaten über die Tasten Ihres TAN-Generator."

--- a/adapters/sparkasse-adapter/src/test/resources/pis/payments/sepa-credit-transfers/select-sca-method.json
+++ b/adapters/sparkasse-adapter/src/test/resources/pis/payments/sepa-credit-transfers/select-sca-method.json
@@ -8,7 +8,7 @@
       "Content-Type": "application/json; charset=UTF-8"
     },
     "body": {
-      "authenticationMethodId": "MANUAL"
+      "authenticationMethodId": "OPTICAL"
     }
   },
   "response": {
@@ -16,7 +16,7 @@
       "scaStatus": "scaMethodSelected",
       "chosenScaMethod": {
         "authenticationType": "CHIP_OTP",
-        "authenticationMethodId": "MANUAL",
+        "authenticationMethodId": "OPTICAL",
         "authenticationVersion": "HHD1.3.2",
         "name": "chipTAN MANUAL | Kartennummer: ******9876",
         "explanation": "Erfassung der Auftragsdaten über die Tasten Ihres TAN-Generator."

--- a/docs/release_notes/DRAFT_Release_notes_0.1.16.adoc
+++ b/docs/release_notes/DRAFT_Release_notes_0.1.16.adoc
@@ -11,3 +11,4 @@
 
 == Fixes:
 - amended `release` script and rearranged steps.
+- adjusted WireMock stubs for `sparkasse-adapter` to work in both WireMock tests and in WireMock Mode.


### PR DESCRIPTION
Sparkasse stubs were configured to comfort tests only but don't work in WireMock mode. Fixed that.