### PR TITLE
Extending Fiducia booking statuses list 

### DIFF
--- a/adapters/fiducia-adapter/src/main/java/de/adorsys/xs2a/adapter/fiducia/FiduciaAccountInformationService.java
+++ b/adapters/fiducia-adapter/src/main/java/de/adorsys/xs2a/adapter/fiducia/FiduciaAccountInformationService.java
@@ -33,12 +33,10 @@ import de.adorsys.xs2a.adapter.impl.BaseAccountInformationService;
 import org.mapstruct.factory.Mappers;
 
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
 public class FiduciaAccountInformationService extends BaseAccountInformationService {
-//    private static final Set<String> SUPPORTED_BOOKING_STATUSES = new HashSet<>(Collections.singletonList("booked"));
     private static final Set<String> SUPPORTED_BOOKING_STATUSES = Set.of("booked", "information");
     private static final String BOOKING_STATUS_ERROR_MESSAGE = String.format(
         "ASPSP supports only the following booking statuses: %s. " +

--- a/adapters/fiducia-adapter/src/main/java/de/adorsys/xs2a/adapter/fiducia/FiduciaAccountInformationService.java
+++ b/adapters/fiducia-adapter/src/main/java/de/adorsys/xs2a/adapter/fiducia/FiduciaAccountInformationService.java
@@ -38,7 +38,8 @@ import java.util.List;
 import java.util.Set;
 
 public class FiduciaAccountInformationService extends BaseAccountInformationService {
-    private static final Set<String> SUPPORTED_BOOKING_STATUSES = new HashSet<>(Collections.singletonList("booked"));
+//    private static final Set<String> SUPPORTED_BOOKING_STATUSES = new HashSet<>(Collections.singletonList("booked"));
+    private static final Set<String> SUPPORTED_BOOKING_STATUSES = Set.of("booked", "information");
     private static final String BOOKING_STATUS_ERROR_MESSAGE = String.format(
         "ASPSP supports only the following booking statuses: %s. " +
             "The booking status from the request has to be changed to the supported ones.",

--- a/adapters/fiducia-adapter/src/test/java/de/adorsys/xs2a/adapter/fiducia/FiduciaAccountInformationServiceTest.java
+++ b/adapters/fiducia-adapter/src/test/java/de/adorsys/xs2a/adapter/fiducia/FiduciaAccountInformationServiceTest.java
@@ -14,6 +14,8 @@ import de.adorsys.xs2a.adapter.impl.link.identity.IdentityLinksRewriter;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mockito;
 
 import java.io.ByteArrayInputStream;
@@ -41,6 +43,17 @@ class FiduciaAccountInformationServiceTest {
         when(httpClientFactory.getHttpClientConfig()).thenReturn(httpClientConfig);
 
         service = new FiduciaAccountInformationService(new Aspsp(), httpClientFactory, null, new IdentityLinksRewriter());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"booked", "information"})
+    void getTransactionList_success_checkSupportedBookingStatuses(String status) {
+        RequestHeaders requestHeaders = RequestHeaders.fromMap(new HashMap<>());
+        RequestParams requestParams = RequestParams.fromMap(buildRequestParamsMapWithBookingStatus(status));
+
+        Assertions.assertDoesNotThrow(
+            () -> service.validateGetTransactionList(ACCOUNT_ID, requestHeaders, requestParams)
+        );
     }
 
     @Test


### PR DESCRIPTION
Add new supported booking status to FiduciaAccountInformationService,
add test to check supported statuses validation